### PR TITLE
feat: 配置自动构建release与镜像的action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,6 @@ fabric.properties
 go.work
 k8m
 tmp/
-bin/
 /def.json
 /example.json
 /uploads/

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@ fabric.properties
 go.work
 k8m
 tmp/
+bin/
 /def.json
 /example.json
 /uploads/

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,41 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+version-template: $MAJOR.$MINOR.$PATCH
+# Emoji reference: https://gitmoji.carloscuesta.me/
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'kind/feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'regression'
+      - 'kind/bug'
+  - title: 📝 Documentation updates
+    labels:
+      - documentation
+      - 'kind/doc'
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - dependencies
+      - 'kind/chore'
+      - 'kind/dep'
+  - title: 🚦 Tests
+    labels:
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+change-template: '* $TITLE (#$NUMBER) @$AUTHOR'
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -65,6 +65,12 @@ jobs:
       run: |
         make build-linux
 
+    - name: Upload workspace
+      uses: actions/upload-artifact@v4
+      with:
+        name: workspace
+        path: .  # 上传当前工作目录全部内容
+
   buildImage:
     needs: buildx
     runs-on: ubuntu-latest
@@ -76,6 +82,14 @@ jobs:
       run: |
         platform=${{ matrix.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - name: Download workspace
+      uses: actions/download-artifact@v4
+      with:
+        name: workspace
+        path: .  # 覆盖当前目录
+    - name: Verify files
+      run: cat output.txt  # 此时可读取 job1 生成的文件
     - name: print env
       run: |
         env

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -107,7 +107,8 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         cache-from: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache
         cache-to: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache,mode=max
-        platforms: linux/amd64,linux/arm64
+        # platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         # 给清单打上多个标签
         tags: |
           ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -69,9 +69,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: workspace
-        path: |
-          .
-          !ui/node_modules
+        path: bin
 
   buildImage:
     needs: buildx
@@ -84,6 +82,8 @@ jobs:
       run: |
         platform=${{ matrix.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - uses: actions/checkout@v4
 
     - name: Download workspace
       uses: actions/download-artifact@v4
@@ -136,6 +136,7 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         build-args: |
           PLATFORM=${{ env.PLATFORM_PAIR }}
+          --platform=${{ matrix.platform }}
         # 给清单打上多个标签
         tags: |
           ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -66,6 +66,7 @@ jobs:
         make build-linux
 
   buildImage:
+    needs: buildx
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -75,6 +76,9 @@ jobs:
       run: |
         platform=${{ matrix.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+    - name: print env
+      run: |
+        env
 
     - uses: actions/checkout@v4
     - name: Inject slug/short variables

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,89 @@
+# This is a basic workflow to help you get started with Actions
+
+name: build docker image
+
+# Controls when the action will run.
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [created,published] # 表示在创建新的 Release 时触发
+
+# Allows you to run this workflow manually from the Actions tab
+  # 可以手动触发
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Test scenario tags'
+
+environment:
+  DOCKERHUB_USERNAME: eryajf
+  ALIHUB_USERNAME: eryajf
+  IMAGE_REPONAME: k8m
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
+          platforms: linux/arm64,linux/amd64
+          # 镜像推送时间
+          push: ${{ github.event_name != 'pull_request' }}
+          # 给清单打上多个标签
+          tags: |
+            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
+
+      # 镜像推送到 阿里云仓库
+      - name: Login to the Ali Registry
+        uses: docker/login-action@v2
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ env.ALIHUB_USERNAME }}
+          password: ${{ secrets.ALIHUB_TOKEN }}
+
+      - name: Build and push to Ali
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            registry.cn-hangzhou.aliyuncs.com/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
+            registry.cn-hangzhou.aliyuncs.com/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -48,8 +48,7 @@ jobs:
       run: |
         cd ui
         pnpm install
-    - name: 编译前端
-      run: pnpm build
+        pnpm build
 
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -103,7 +103,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        file: ./Dockerfile
+        file: ./Dockerfile.action
         push: ${{ github.event_name != 'pull_request' }}
         cache-from: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache
         cache-to: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache,mode=max

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -43,6 +43,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
+        cache-dependency-path: 'ui/pnpm-lock.yaml'
     - name: 安装依赖
       run: |
         cd ui

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -44,28 +44,13 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
         cache-dependency-path: 'ui/pnpm-lock.yaml'
-    - name: 安装依赖
+    - name: 编译前端
       run: |
         cd ui
         pnpm install
         pnpm build
 
-    # - name: Set up Go
-    #   uses: actions/setup-go@v5
-    #   with:
-    #     go-version-file: 'go.mod'
-    #     cache-dependency-path: 'go.sum'
-
-    # - name: Install UPX
-    #   uses: crazy-max/ghaction-upx@v3
-    #   with:
-    #     install-only: true
-
-    # - name: 安装依赖
-    #   run: |
-    #     make build-linux
-
-    - name: Upload workspace
+    - name: 上传到共享
       uses: actions/upload-artifact@v4
       with:
         name: workspace
@@ -77,17 +62,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Download workspace
+    - name: 从共享下载
       uses: actions/download-artifact@v4
       with:
         name: workspace
         path: ui/dist  # 覆盖当前目录
-
-    - name: print env
-      run: |
-        env
-        ls -l
-        ls -l ui/
 
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -121,11 +121,13 @@ jobs:
         password: ${{ secrets.ALIHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile
         push: ${{ github.event_name != 'pull_request' }}
+        cache-from: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache
+        cache-to: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache,mode=max
         platforms: linux/amd64,linux/arm64
         # 给清单打上多个标签
         tags: |

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -51,7 +51,7 @@ jobs:
         pnpm build
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
         cache-dependency-path: 'go.sum'
@@ -65,51 +65,51 @@ jobs:
       run: |
         make build-linux
 
-    - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
+    # - name: Inject slug/short variables
+    #   uses: rlespinasse/github-slug-action@v4
 
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
+    # - name: Get current date
+    #   id: date
+    #   run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+    # - name: Set up QEMU
+    #   uses: docker/setup-qemu-action@v2
 
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
+    # - name: Set up Docker Buildx
+    #   id: buildx
+    #   uses: docker/setup-buildx-action@v2
 
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
+    # - name: Available platforms
+    #   run: echo ${{ steps.buildx.outputs.platforms }}
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ env.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    # - name: Login to DockerHub
+    #   uses: docker/login-action@v2
+    #   with:
+    #     username: ${{ env.DOCKERHUB_USERNAME }}
+    #     password: ${{ secrets.DOCKERHUB_TOKEN }}
         
-    # 镜像推送到 阿里云仓库
-    - name: Login to the Ali Registry
-      uses: docker/login-action@v2
-      with:
-        registry: ${{ env.ALIHUB_URL }}
-        username: ${{ env.ALIHUB_USERNAME }}
-        password: ${{ secrets.ALIHUB_TOKEN }}
+    # # 镜像推送到 阿里云仓库
+    # - name: Login to the Ali Registry
+    #   uses: docker/login-action@v2
+    #   with:
+    #     registry: ${{ env.ALIHUB_URL }}
+    #     username: ${{ env.ALIHUB_USERNAME }}
+    #     password: ${{ secrets.ALIHUB_TOKEN }}
 
-    - name: Build and push
-      uses: docker/build-push-action@v4
-      with:
-        context: .
-        file: ./Dockerfile.action
-        # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
-        platforms: linux/arm64,linux/amd64
-        # 镜像推送时间
-        push: ${{ github.event_name != 'pull_request' }}
-        build-args: |
-          PLATFORM=${{ env.platform }}
-        # 给清单打上多个标签
-        tags: |
-          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
-          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
-          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
-          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+    # - name: Build and push
+    #   uses: docker/build-push-action@v4
+    #   with:
+    #     context: .
+    #     file: ./Dockerfile.action
+    #     # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
+    #     platforms: linux/arm64,linux/amd64
+    #     # 镜像推送时间
+    #     push: ${{ github.event_name != 'pull_request' }}
+    #     build-args: |
+    #       PLATFORM=${{ env.platform }}
+    #     # 给清单打上多个标签
+    #     tags: |
+    #       ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+    #       ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
+    #       ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
+    #       ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -33,7 +33,13 @@ jobs:
     strategy:
       matrix:
         node-version: [18]
+        platform: [linux/arm64, linux/amd64]  # 与 platforms 列表一致
     steps:
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
@@ -65,51 +71,48 @@ jobs:
       run: |
         make build-linux
 
-    # - name: Inject slug/short variables
-    #   uses: rlespinasse/github-slug-action@v4
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
 
-    # - name: Get current date
-    #   id: date
-    #   run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
 
-    # - name: Set up QEMU
-    #   uses: docker/setup-qemu-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-    # - name: Set up Docker Buildx
-    #   id: buildx
-    #   uses: docker/setup-buildx-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
 
-    # - name: Available platforms
-    #   run: echo ${{ steps.buildx.outputs.platforms }}
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
 
-    # - name: Login to DockerHub
-    #   uses: docker/login-action@v2
-    #   with:
-    #     username: ${{ env.DOCKERHUB_USERNAME }}
-    #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-        
-    # # 镜像推送到 阿里云仓库
-    # - name: Login to the Ali Registry
-    #   uses: docker/login-action@v2
-    #   with:
-    #     registry: ${{ env.ALIHUB_URL }}
-    #     username: ${{ env.ALIHUB_USERNAME }}
-    #     password: ${{ secrets.ALIHUB_TOKEN }}
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    # - name: Build and push
-    #   uses: docker/build-push-action@v4
-    #   with:
-    #     context: .
-    #     file: ./Dockerfile.action
-    #     # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
-    #     platforms: linux/arm64,linux/amd64
-    #     # 镜像推送时间
-    #     push: ${{ github.event_name != 'pull_request' }}
-    #     build-args: |
-    #       PLATFORM=${{ env.platform }}
-    #     # 给清单打上多个标签
-    #     tags: |
-    #       ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
-    #       ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
-    #       ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
-    #       ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+    # 镜像推送到 阿里云仓库
+    - name: Login to the Ali Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.ALIHUB_URL }}
+        username: ${{ env.ALIHUB_USERNAME }}
+        password: ${{ secrets.ALIHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./Dockerfile.action
+        push: ${{ github.event_name != 'pull_request' }}
+        build-args: |
+          PLATFORM=${{ env.PLATFORM_PAIR }}
+        # 给清单打上多个标签
+        tags: |
+          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
+          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
+          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -128,8 +128,7 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         cache-from: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache
         cache-to: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache,mode=max
-        # platforms: linux/amd64,linux/arm64
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         # 给清单打上多个标签
         tags: |
           ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -65,49 +65,51 @@ jobs:
       run: |
         make build-linux
 
-    # - name: Inject slug/short variables
-    #   uses: rlespinasse/github-slug-action@v4
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
 
-    # - name: Get current date
-    #   id: date
-    #   run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
 
-    # - name: Set up QEMU
-    #   uses: docker/setup-qemu-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-    # - name: Set up Docker Buildx
-    #   id: buildx
-    #   uses: docker/setup-buildx-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
 
-    # - name: Available platforms
-    #   run: echo ${{ steps.buildx.outputs.platforms }}
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
 
-    # - name: Login to DockerHub
-    #   uses: docker/login-action@v2
-    #   with:
-    #     username: ${{ env.DOCKERHUB_USERNAME }}
-    #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
         
-    # # 镜像推送到 阿里云仓库
-    # - name: Login to the Ali Registry
-    #   uses: docker/login-action@v2
-    #   with:
-    #     registry: ${{ env.ALIHUB_URL }}
-    #     username: ${{ env.ALIHUB_USERNAME }}
-    #     password: ${{ secrets.ALIHUB_TOKEN }}
+    # 镜像推送到 阿里云仓库
+    - name: Login to the Ali Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.ALIHUB_URL }}
+        username: ${{ env.ALIHUB_USERNAME }}
+        password: ${{ secrets.ALIHUB_TOKEN }}
 
-    # - name: Build and push
-    #   uses: docker/build-push-action@v4
-    #   with:
-    #     context: .
-    #     file: ./Dockerfile
-    #     # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
-    #     platforms: linux/arm64,linux/amd64
-    #     # 镜像推送时间
-    #     push: ${{ github.event_name != 'pull_request' }}
-    #     # 给清单打上多个标签
-    #     tags: |
-    #       ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
-    #       ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
-    #       ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
-    #       ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./Dockerfile.action
+        # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
+        platforms: linux/arm64,linux/amd64
+        # 镜像推送时间
+        push: ${{ github.event_name != 'pull_request' }}
+        build-args: |
+          PLATFORM=${{ env.platform }}
+        # 给清单打上多个标签
+        tags: |
+          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
+          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
+          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -128,7 +128,8 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         cache-from: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache
         cache-to: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache,mode=max
-        platforms: linux/amd64,linux/arm64
+        # platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         # 给清单打上多个标签
         tags: |
           ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -82,7 +82,6 @@ jobs:
     steps:
     - name: Prepare
       run: |
-        mv bin/* ./
         platform=${{ matrix.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
@@ -94,10 +93,10 @@ jobs:
 
     - name: print env
       run: |
+        mv bin/* ./
         env
         ls -l
 
-    - uses: actions/checkout@v4
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -69,7 +69,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: workspace
-        path: .  # 上传当前工作目录全部内容
+        path: |
+          .
+          !ui/node_modules
 
   buildImage:
     needs: buildx
@@ -88,8 +90,7 @@ jobs:
       with:
         name: workspace
         path: .  # 覆盖当前目录
-    - name: Verify files
-      run: cat output.txt  # 此时可读取 job1 生成的文件
+
     - name: print env
       run: |
         env

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -50,51 +50,44 @@ jobs:
         pnpm install
         pnpm build
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache-dependency-path: 'go.sum'
+    # - name: Set up Go
+    #   uses: actions/setup-go@v5
+    #   with:
+    #     go-version-file: 'go.mod'
+    #     cache-dependency-path: 'go.sum'
 
-    - name: Install UPX
-      uses: crazy-max/ghaction-upx@v3
-      with:
-        install-only: true
+    # - name: Install UPX
+    #   uses: crazy-max/ghaction-upx@v3
+    #   with:
+    #     install-only: true
 
-    - name: 安装依赖
-      run: |
-        make build-linux
+    # - name: 安装依赖
+    #   run: |
+    #     make build-linux
 
     - name: Upload workspace
       uses: actions/upload-artifact@v4
       with:
         name: workspace
-        path: bin
+        path: ui/dist
 
   buildImage:
     needs: buildx
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [linux/arm64, linux/amd64]  # 与 platforms 列表一致
     steps:
-    - name: Prepare
-      run: |
-        platform=${{ matrix.platform }}
-        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
     - uses: actions/checkout@v4
 
     - name: Download workspace
       uses: actions/download-artifact@v4
       with:
         name: workspace
-        path: .  # 覆盖当前目录
+        path: ui/dist  # 覆盖当前目录
 
     - name: print env
       run: |
         env
         ls -l
+        ls -l ui/
 
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4
@@ -131,11 +124,9 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: .
-        file: ./Dockerfile.action
+        file: ./Dockerfile
         push: ${{ github.event_name != 'pull_request' }}
-        build-args: |
-          PLATFORM=${{ env.PLATFORM_PAIR }}
-          --platform=${{ matrix.platform }}
+        platforms: linux/amd64,linux/arm64
         # 给清单打上多个标签
         tags: |
           ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -82,6 +82,7 @@ jobs:
     steps:
     - name: Prepare
       run: |
+        mv bin/* ./
         platform=${{ matrix.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
@@ -95,10 +96,6 @@ jobs:
       run: |
         env
         ls -l
-        echo "-------------------------------"
-        ls -l bin
-        echo "-------------------------------"
-        ls -l ui
 
     - uses: actions/checkout@v4
     - name: Inject slug/short variables

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -33,13 +33,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18]
-        platform: [linux/arm64, linux/amd64]  # 与 platforms 列表一致
     steps:
-    - name: Prepare
-      run: |
-        platform=${{ matrix.platform }}
-        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
@@ -71,6 +65,18 @@ jobs:
       run: |
         make build-linux
 
+  buildImage:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/arm64, linux/amd64]  # 与 platforms 列表一致
+    steps:
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - uses: actions/checkout@v4
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -30,53 +30,69 @@ env:
 jobs:
   buildx:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+    - uses: pnpm/action-setup@v4
+      with:
+        version: latest
+    - name: 使用 Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+    - name: 安装依赖
+      run: |
+        cd ui
+        pnpm install
+    - name: 编译前端
+      run: pnpm build
 
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
 
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
 
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          
-      # 镜像推送到 阿里云仓库
-      - name: Login to the Ali Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.ALIHUB_URL }}
-          username: ${{ env.ALIHUB_USERNAME }}
-          password: ${{ secrets.ALIHUB_TOKEN }}
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        
+    # 镜像推送到 阿里云仓库
+    - name: Login to the Ali Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.ALIHUB_URL }}
+        username: ${{ env.ALIHUB_USERNAME }}
+        password: ${{ secrets.ALIHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Dockerfile
-          # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
-          platforms: linux/arm64,linux/amd64
-          # 镜像推送时间
-          push: ${{ github.event_name != 'pull_request' }}
-          # 给清单打上多个标签
-          tags: |
-            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
-            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
-            ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
-            ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./Dockerfile
+        # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
+        platforms: linux/arm64,linux/amd64
+        # 镜像推送时间
+        push: ${{ github.event_name != 'pull_request' }}
+        # 给清单打上多个标签
+        tags: |
+          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
+          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
+          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,6 +23,7 @@ on:
 
 env:
   DOCKERHUB_USERNAME: eryajf
+  ALIHUB_URL: registry.cn-hangzhou.aliyuncs.com
   ALIHUB_USERNAME: eryajf
   IMAGE_REPONAME: k8m
 
@@ -55,6 +56,14 @@ jobs:
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
+      # 镜像推送到 阿里云仓库
+      - name: Login to the Ali Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.ALIHUB_URL }}
+          username: ${{ env.ALIHUB_USERNAME }}
+          password: ${{ secrets.ALIHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v4
@@ -69,21 +78,5 @@ jobs:
           tags: |
             ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
             ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
-
-      # 镜像推送到 阿里云仓库
-      - name: Login to the Ali Registry
-        uses: docker/login-action@v2
-        with:
-          registry: registry.cn-hangzhou.aliyuncs.com
-          username: ${{ env.ALIHUB_USERNAME }}
-          password: ${{ secrets.ALIHUB_TOKEN }}
-
-      - name: Build and push to Ali
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            registry.cn-hangzhou.aliyuncs.com/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
-            registry.cn-hangzhou.aliyuncs.com/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+            ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
+            ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -93,7 +93,6 @@ jobs:
 
     - name: print env
       run: |
-        mv bin/* ./
         env
         ls -l
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -50,49 +50,62 @@ jobs:
         pnpm install
         pnpm build
 
-    - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
-
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-
-    - name: Login to DockerHub
-      uses: docker/login-action@v2
+    - name: Set up Go
+      uses: actions/setup-go@v3
       with:
-        username: ${{ env.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        go-version-file: 'go.mod'
+        cache-dependency-path: 'go.sum'
+
+    - name: 安装依赖
+      run: |
+        apt install -y make wget
+        wget https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-amd64_linux.tar.xz
+        tar xf upx-5.0.0-amd64_linux.tar.xz && mv upx-5.0.0-amd64_linux /usr/local/bin/upx
+        chmod +x /usr/local/bin/upx && make build-linux
+
+    # - name: Inject slug/short variables
+    #   uses: rlespinasse/github-slug-action@v4
+
+    # - name: Get current date
+    #   id: date
+    #   run: echo "::set-output name=today::$(date +'%Y-%m-%d_%H-%M')"
+
+    # - name: Set up QEMU
+    #   uses: docker/setup-qemu-action@v2
+
+    # - name: Set up Docker Buildx
+    #   id: buildx
+    #   uses: docker/setup-buildx-action@v2
+
+    # - name: Available platforms
+    #   run: echo ${{ steps.buildx.outputs.platforms }}
+
+    # - name: Login to DockerHub
+    #   uses: docker/login-action@v2
+    #   with:
+    #     username: ${{ env.DOCKERHUB_USERNAME }}
+    #     password: ${{ secrets.DOCKERHUB_TOKEN }}
         
-    # 镜像推送到 阿里云仓库
-    - name: Login to the Ali Registry
-      uses: docker/login-action@v2
-      with:
-        registry: ${{ env.ALIHUB_URL }}
-        username: ${{ env.ALIHUB_USERNAME }}
-        password: ${{ secrets.ALIHUB_TOKEN }}
+    # # 镜像推送到 阿里云仓库
+    # - name: Login to the Ali Registry
+    #   uses: docker/login-action@v2
+    #   with:
+    #     registry: ${{ env.ALIHUB_URL }}
+    #     username: ${{ env.ALIHUB_USERNAME }}
+    #     password: ${{ secrets.ALIHUB_TOKEN }}
 
-    - name: Build and push
-      uses: docker/build-push-action@v4
-      with:
-        context: .
-        file: ./Dockerfile
-        # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
-        platforms: linux/arm64,linux/amd64
-        # 镜像推送时间
-        push: ${{ github.event_name != 'pull_request' }}
-        # 给清单打上多个标签
-        tags: |
-          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
-          ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
-          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
-          ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+    # - name: Build and push
+    #   uses: docker/build-push-action@v4
+    #   with:
+    #     context: .
+    #     file: ./Dockerfile
+    #     # 所需要的体系结构，可以在 Available platforms 步骤中获取所有的可用架构
+    #     platforms: linux/arm64,linux/amd64
+    #     # 镜像推送时间
+    #     push: ${{ github.event_name != 'pull_request' }}
+    #     # 给清单打上多个标签
+    #     tags: |
+    #       ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest
+    #       ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
+    #       ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
+    #       ${{ env.ALIHUB_URL }}/${{ env.ALIHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -56,12 +56,14 @@ jobs:
         go-version-file: 'go.mod'
         cache-dependency-path: 'go.sum'
 
+    - name: Install UPX
+      uses: crazy-max/ghaction-upx@v3
+      with:
+        install-only: true
+
     - name: 安装依赖
       run: |
-        apt install -y make wget
-        wget https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-amd64_linux.tar.xz
-        tar xf upx-5.0.0-amd64_linux.tar.xz && mv upx-5.0.0-amd64_linux /usr/local/bin/upx
-        chmod +x /usr/local/bin/upx && make build-linux
+        make build-linux
 
     # - name: Inject slug/short variables
     #   uses: rlespinasse/github-slug-action@v4

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -79,6 +79,11 @@ jobs:
     - name: print env
       run: |
         env
+        ls -l
+        echo "-------------------------------"
+        ls -l bin
+        echo "-------------------------------"
+        ls -l ui
 
     - uses: actions/checkout@v4
     - name: Inject slug/short variables

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -21,7 +21,7 @@ on:
       tags:
         description: 'Test scenario tags'
 
-environment:
+env:
   DOCKERHUB_USERNAME: eryajf
   ALIHUB_USERNAME: eryajf
   IMAGE_REPONAME: k8m

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,36 @@
+name: build and push binary to release
+
+on:
+  release:
+    types: [created,published] # 表示在创建新的 Release 时触发
+
+jobs:
+  build-go-binary:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin] # 需要打包的系统
+        goarch: [amd64, arm64] # 需要打包的架构
+        exclude: # 排除某些平台和架构
+          - goarch: arm64
+            goos: windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: build node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: |
+          npm i -g pnpm
+          pnpm install
+          pnpm build
+
+      - uses: wangyoucao577/go-release-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # 一个默认的变量，用来实现往 Release 中添加文件
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: 1.24
+          binary_name: "k8m"
+          extra_files: LICENSE README.md

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,46 +28,60 @@ jobs:
         pnpm install
         pnpm build
 
-    - name: 设置go环境
-      uses: actions/setup-go@v5
+    - name: 上传到共享
+      uses: actions/upload-artifact@v4
       with:
-        go-version-file: 'go.mod'
-        cache-dependency-path: 'go.sum'
+        name: workspace
+        path: ui/dist
 
-    - name: 安装 UPX
-      uses: crazy-max/ghaction-upx@v3
-      with:
-        install-only: true
+    # - name: 设置go环境
+    #   uses: actions/setup-go@v5
+    #   with:
+    #     go-version-file: 'go.mod'
+    #     cache-dependency-path: 'go.sum'
 
-    - name: 编译后端
-      run: |
-        make build-all
+    # - name: 安装 UPX
+    #   uses: crazy-max/ghaction-upx@v3
+    #   with:
+    #     install-only: true
 
-    - name: 上传二进制
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: bin/k8m*
-        tag: ${{ github.ref }}
-        overwrite: true
-        file_glob: true
+    # - name: 编译后端
+    #   run: |
+    #     make build-all
 
-  # build-go-binary:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       goos: [linux, windows, darwin]
-  #       goarch: [amd64, arm64]
-  #       exclude:
-  #         - goarch: arm64
-  #           goos: windows
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: wangyoucao577/go-release-action@v1
-  #       with:
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         goos: ${{ matrix.goos }}
-  #         goarch: ${{ matrix.goarch }}
-  #         goversion: 1.24
-  #         binary_name: "k8m"
-  #         extra_files: LICENSE README.md
+    # - name: 上传二进制
+    #   uses: svenstaro/upload-release-action@v2
+    #   with:
+    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+    #     file: bin/k8m*
+    #     tag: ${{ github.ref }}
+    #     overwrite: true
+    #     file_glob: true
+
+  build-go-binary:
+    needs: build-frontend
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        exclude:
+          - goarch: arm64
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: 从共享下载
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+          path: ui/dist
+
+      - uses: wangyoucao577/go-release-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: 1.24
+          binary_name: "k8m"
+          extra_files: LICENSE README.md
+          executable_compression: 'upx -v -9'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,33 +7,67 @@ on:
 jobs:
   build-frontend:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: pnpm
-      - run: |
-          npm i -g pnpm
-          pnpm install
-          pnpm build
-
-  build-go-binary:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
-        exclude:
-          - goarch: arm64
-            goos: windows
+        node-version: [18]
     steps:
-      - uses: actions/checkout@v4
-      - uses: wangyoucao577/go-release-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          goversion: 1.24
-          binary_name: "k8m"
-          extra_files: LICENSE README.md
+    - uses: actions/checkout@v4
+    - uses: pnpm/action-setup@v4
+      with:
+        version: latest
+    - name: 使用 Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+        cache-dependency-path: 'ui/pnpm-lock.yaml'
+
+    - name: 编译前端
+      run: |
+        cd ui
+        pnpm install
+        pnpm build
+
+    - name: 设置go环境
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache-dependency-path: 'go.sum'
+
+    - name: 安装 UPX
+      uses: crazy-max/ghaction-upx@v3
+      with:
+        install-only: true
+
+    - name: 编译后端
+      run: |
+        make build-all
+
+    - name: 上传二进制
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: bin/k8m*
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true
+
+  # build-go-binary:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       goos: [linux, windows, darwin]
+  #       goarch: [amd64, arm64]
+  #       exclude:
+  #         - goarch: arm64
+  #           goos: windows
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: wangyoucao577/go-release-action@v1
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         goos: ${{ matrix.goos }}
+  #         goarch: ${{ matrix.goarch }}
+  #         goversion: 1.24
+  #         binary_name: "k8m"
+  #         extra_files: LICENSE README.md

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,54 +34,26 @@ jobs:
         name: workspace
         path: ui/dist
 
-    # - name: 设置go环境
-    #   uses: actions/setup-go@v5
-    #   with:
-    #     go-version-file: 'go.mod'
-    #     cache-dependency-path: 'go.sum'
+    - name: 设置go环境
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache-dependency-path: 'go.sum'
 
-    # - name: 安装 UPX
-    #   uses: crazy-max/ghaction-upx@v3
-    #   with:
-    #     install-only: true
+    - name: 安装 UPX
+      uses: crazy-max/ghaction-upx@v3
+      with:
+        install-only: true
 
-    # - name: 编译后端
-    #   run: |
-    #     make build-all
+    - name: 编译后端
+      run: |
+        make build-all
 
-    # - name: 上传二进制
-    #   uses: svenstaro/upload-release-action@v2
-    #   with:
-    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-    #     file: bin/k8m*
-    #     tag: ${{ github.ref }}
-    #     overwrite: true
-    #     file_glob: true
-
-  build-go-binary:
-    needs: build-frontend
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
-        exclude:
-          - goarch: arm64
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: 从共享下载
-        uses: actions/download-artifact@v4
-        with:
-          name: workspace
-          path: ui/dist
-
-      - uses: wangyoucao577/go-release-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          goversion: 1.24
-          binary_name: "k8m"
-          extra_files: LICENSE README.md
-          executable_compression: 'upx -v -9'
+    - name: 上传二进制
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: bin/k8m*
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -5,30 +5,33 @@ on:
     types: [created,published] # 表示在创建新的 Release 时触发
 
 jobs:
-  build-go-binary:
+  build-frontend:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, windows, darwin] # 需要打包的系统
-        goarch: [amd64, arm64] # 需要打包的架构
-        exclude: # 排除某些平台和架构
-          - goarch: arm64
-            goos: windows
     steps:
       - uses: actions/checkout@v4
-
-      - name: build node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: pnpm
       - run: |
           npm i -g pnpm
           pnpm install
           pnpm build
 
+  build-go-binary:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        exclude:
+          - goarch: arm64
+            goos: windows
+    steps:
+      - uses: actions/checkout@v4
       - uses: wangyoucao577/go-release-action@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }} # 一个默认的变量，用来实现往 Release 中添加文件
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: 1.24

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,38 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,42 @@
-FROM golang:alpine AS builder
-ARG VERSION
-ARG GIT_COMMIT
-ARG MODEL
-ARG API_KEY
-ARG API_URL
-WORKDIR /app
-COPY go.mod go.sum /app/
-RUN go mod download
-COPY . /app
-RUN CGO_ENABLED=0 go build -ldflags "-s -w  -X main.Version=$VERSION -X main.GitCommit=$GIT_COMMIT -X main.Model=$MODEL -X main.ApiKey=$API_KEY -X main.ApiUrl=$API_URL" \
-    -o /app/k8m
-
-FROM alpine:latest
+FROM node:18-alpine  AS node-builder
 
 WORKDIR /app
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
-RUN apk add --no-cache curl bash inotify-tools kubectl
-ADD reload.sh /app/reload.sh
-RUN chmod +x /app/reload.sh
 
-COPY --from=builder /app/k8m /app/k8m
+ADD ui .
+
+RUN npm i -g pnpm && pnpm install && pnpm build
+
+FROM golang:1.24-alpine  AS golang-builder
+
+ENV GOPROXY="https://goproxy.io"
+
+WORKDIR /app
+
+ADD . .
+COPY --from=node-builder /app/dist ./ui/dist
+
+RUN sed -i "s/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g" /etc/apk/repositories \
+    && apk upgrade && apk add --no-cache --virtual .build-deps \
+    ca-certificates gcc g++ curl upx
+
+RUN go build -o k8m . && upx -9 k8m
+
+### build final image
+FROM alpine:3.21
+
+WORKDIR /app
+
+ENV TZ=Asia/Shanghai
+
+COPY --from=golang-builder /app/k8m .
+
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
+    && apk upgrade && apk add --no-cache curl bash inotify-tools kubectl alpine-conf busybox-extras sqlite tzdata \
+    && apk del alpine-conf && rm -rf /var/cache/* && chmod +x k8m
+
 #k8m Server
 EXPOSE 3618
 #MCP Server
 EXPOSE 3619 
-ENTRYPOINT ["/app/reload.sh","k8m","/app"]
+
+CMD /app/k8m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,27 @@
-FROM golang:1.24-alpine  AS golang-builder
+FROM golang:alpine AS builder
+ARG VERSION
+ARG GIT_COMMIT
+ARG MODEL
+ARG API_KEY
+ARG API_URL
+WORKDIR /app
+COPY go.mod go.sum /app/
+RUN go mod download
+COPY . /app
+RUN CGO_ENABLED=0 go build -ldflags "-s -w  -X main.Version=$VERSION -X main.GitCommit=$GIT_COMMIT -X main.Model=$MODEL -X main.ApiKey=$API_KEY -X main.ApiUrl=$API_URL" \
+    -o /app/k8m
 
-ENV GOPROXY="https://goproxy.io"
+FROM alpine:latest
 
 WORKDIR /app
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+RUN apk add --no-cache curl bash inotify-tools kubectl
+ADD reload.sh /app/reload.sh
+RUN chmod +x /app/reload.sh
 
-ADD . .
-
-RUN apk add upx
-RUN --mount=type=cache,target=/go/pkg/mod \
-    go build -o k8m . && apk add upx && upx -9 k8m
-
-### build final image
-FROM alpine:3.21
-
-WORKDIR /app
-
-ENV TZ=Asia/Shanghai
-
-COPY --from=golang-builder /app/k8m .
-
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
-    && apk upgrade && apk add --no-cache curl bash inotify-tools kubectl alpine-conf busybox-extras sqlite tzdata \
-    && apk del alpine-conf && rm -rf /var/cache/* && chmod +x k8m
-
+COPY --from=builder /app/k8m /app/k8m
 #k8m Server
 EXPOSE 3618
 #MCP Server
-EXPOSE 3619
-
-CMD /app/k8m
+EXPOSE 3619 
+ENTRYPOINT ["/app/reload.sh","k8m","/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ WORKDIR /app
 
 ADD . .
 
-RUN sed -i "s/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g" /etc/apk/repositories \
-    && apk upgrade && apk add --no-cache --virtual .build-deps \
-    ca-certificates gcc g++ curl upx
-
-RUN go build -o k8m . && upx -9 k8m
+RUN apk add upx
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go build -o k8m . && apk add upx && upx -9 k8m
 
 ### build final image
 FROM alpine:3.21

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,6 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 #k8m Server
 EXPOSE 3618
 #MCP Server
-EXPOSE 3619 
+EXPOSE 3619
 
 CMD /app/k8m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,3 @@
-FROM node:18-alpine  AS node-builder
-
-WORKDIR /app
-
-ADD ui .
-
-RUN npm i -g pnpm && pnpm install && pnpm build
-
 FROM golang:1.24-alpine  AS golang-builder
 
 ENV GOPROXY="https://goproxy.io"
@@ -13,7 +5,6 @@ ENV GOPROXY="https://goproxy.io"
 WORKDIR /app
 
 ADD . .
-COPY --from=node-builder /app/dist ./ui/dist
 
 RUN sed -i "s/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g" /etc/apk/repositories \
     && apk upgrade && apk add --no-cache --virtual .build-deps \

--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -6,7 +6,7 @@ WORKDIR /app
 
 ENV TZ=Asia/Shanghai
 
-ADD bin/k8m-v1.0.0-${PLATFORM} k8m
+ADD k8m-v1.0.0-${PLATFORM} k8m
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
     && apk upgrade && apk add --no-cache curl bash inotify-tools kubectl alpine-conf busybox-extras sqlite tzdata \

--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -1,0 +1,20 @@
+FROM alpine:3.21
+
+ARG PLATFORM="linux/amd64"
+
+WORKDIR /app
+
+ENV TZ=Asia/Shanghai
+
+COPY bin/k8m-v1.0.0-${PLATFORM/\//-} k8m
+
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
+    && apk upgrade && apk add --no-cache curl bash inotify-tools kubectl alpine-conf busybox-extras sqlite tzdata \
+    && apk del alpine-conf && rm -rf /var/cache/* && chmod +x k8m
+
+#k8m Server
+EXPOSE 3618
+#MCP Server
+EXPOSE 3619
+
+CMD /app/k8m

--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -6,7 +6,7 @@ WORKDIR /app
 
 ENV TZ=Asia/Shanghai
 
-COPY bin/k8m-v1.0.0-${PLATFORM} k8m
+ADD bin/k8m-v1.0.0-${PLATFORM} k8m
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
     && apk upgrade && apk add --no-cache curl bash inotify-tools kubectl alpine-conf busybox-extras sqlite tzdata \

--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -1,12 +1,23 @@
-FROM alpine:3.21
+FROM golang:1.24-alpine  AS golang-builder
 
-ARG PLATFORM="linux/amd64"
+ENV GOPROXY="https://goproxy.io"
+
+WORKDIR /app
+
+ADD . .
+
+RUN apk add upx
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go build -o k8m . && apk add upx && upx -9 k8m
+
+### build final image
+FROM alpine:3.21
 
 WORKDIR /app
 
 ENV TZ=Asia/Shanghai
 
-ADD k8m-${PLATFORM} k8m
+COPY --from=golang-builder /app/k8m .
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
     && apk upgrade && apk add --no-cache curl bash inotify-tools kubectl alpine-conf busybox-extras sqlite tzdata \

--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -6,7 +6,7 @@ WORKDIR /app
 
 ENV TZ=Asia/Shanghai
 
-ADD k8m-v1.0.0-${PLATFORM} k8m
+ADD k8m-${PLATFORM} k8m
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
     && apk upgrade && apk add --no-cache curl bash inotify-tools kubectl alpine-conf busybox-extras sqlite tzdata \

--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -6,7 +6,7 @@ WORKDIR /app
 
 ENV TZ=Asia/Shanghai
 
-COPY bin/k8m-v1.0.0-${PLATFORM/\//-} k8m
+COPY bin/k8m-v1.0.0-${PLATFORM} k8m
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
     && apk upgrade && apk add --no-cache curl bash inotify-tools kubectl alpine-conf busybox-extras sqlite tzdata \

--- a/Makefile
+++ b/Makefile
@@ -118,14 +118,20 @@ build-all:
 		else \
 			EXT=""; \
 		fi; \
-		OUTPUT_FILE="$(OUTPUT_DIR)/$(BINARY_NAME)-$(VERSION)-$$GOOS-$$GOARCH$$EXT"; \
+		OUTPUT_FILE="$(OUTPUT_DIR)/$(BINARY_NAME)-$$GOOS-$$GOARCH$$EXT"; \
 		ZIP_FILE="$(OUTPUT_FILE).zip"; \
 		echo "输出文件: $$OUTPUT_FILE"; \
 		echo "执行命令: GOOS=$$GOOS GOARCH=$$GOARCH go build -ldflags \"-s -w -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.Model=$(MODEL) -X main.ApiKey=$(API_KEY) -X main.ApiUrl=$(API_URL)\" -o $$OUTPUT_FILE ."; \
 		GOOS=$$GOOS GOARCH=$$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w   -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.Model=$(MODEL) -X main.ApiKey=$(API_KEY) -X main.ApiUrl=$(API_URL)" -o "$$OUTPUT_FILE" .; \
 		echo "打包为 ZIP (最大压缩级别): $$ZIP_FILE"; \
-        (cd $(OUTPUT_DIR) && zip -9 "$(BINARY_NAME)-$(VERSION)-$$GOOS-$$GOARCH.zip" "$(BINARY_NAME)-$(VERSION)-$$GOOS-$$GOARCH$$EXT"); \
+		if [ "$$GOOS" = "windows" ] && [ "$$GOARCH" = "arm64" ]; then \
+			echo "跳过 upx"; \
+		else \
+			upx -9 "$$OUTPUT_FILE"; \
+		fi; \
+        (cd $(OUTPUT_DIR) && zip -9 "$(BINARY_NAME)-$$GOOS-$$GOARCH.zip" "$(BINARY_NAME)-$$GOOS-$$GOARCH$$EXT"); \
         echo "文件已打包: $$ZIP_FILE"; \
+		rm -f "$$OUTPUT_FILE"; \
 	done
 
 # 为所有指定的平台和架构构建可执行文件

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ build-linux:
 		else \
 			EXT=""; \
 		fi; \
-		OUTPUT_FILE="$(OUTPUT_DIR)/$(BINARY_NAME)-$(VERSION)-$$GOOS-$$GOARCH$$EXT"; \
+		OUTPUT_FILE="$(OUTPUT_DIR)/$(BINARY_NAME)-$$GOOS-$$GOARCH$$EXT"; \
 		echo "输出文件: $$OUTPUT_FILE"; \
 		echo "执行命令: GOOS=$$GOOS GOARCH=$$GOARCH go build -ldflags \"-s -w -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.Model=$(MODEL) -X main.ApiKey=$(API_KEY) -X main.ApiUrl=$(API_URL)\" -o $$OUTPUT_FILE ."; \
 		GOOS=$$GOOS GOARCH=$$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w   -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.Model=$(MODEL) -X main.ApiKey=$(API_KEY) -X main.ApiUrl=$(API_URL)" -o "$$OUTPUT_FILE" .; \

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ PLATFORMS := \
     windows/amd64 \
     windows/arm64
 
+# 定义需要编译的Linux平台和架构
+# 格式为 GOOS/GOARCH
+LINUX_PLATFORMS := \
+    linux/amd64 \
+    linux/arm64 \
+
 # 默认目标
 .PHONY: all
 all: build
@@ -122,6 +128,26 @@ build-all:
         echo "文件已打包: $$ZIP_FILE"; \
 	done
 
+# 为所有指定的平台和架构构建可执行文件
+.PHONY: build-linux
+build-linux:
+	@echo "为所有平台构建可执行文件..."
+	@mkdir -p $(OUTPUT_DIR)
+	@for platform in $(LINUX_PLATFORMS); do \
+		GOOS=$${platform%/*} GOARCH=$${platform#*/}; \
+		echo "构建平台: $$GOOS/$$GOARCH ..."; \
+		if [ "$$GOOS" = "windows" ]; then \
+			EXT=".exe"; \
+		else \
+			EXT=""; \
+		fi; \
+		OUTPUT_FILE="$(OUTPUT_DIR)/$(BINARY_NAME)-$(VERSION)-$$GOOS-$$GOARCH$$EXT"; \
+		echo "输出文件: $$OUTPUT_FILE"; \
+		echo "执行命令: GOOS=$$GOOS GOARCH=$$GOARCH go build -ldflags \"-s -w -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.Model=$(MODEL) -X main.ApiKey=$(API_KEY) -X main.ApiUrl=$(API_URL)\" -o $$OUTPUT_FILE ."; \
+		GOOS=$$GOOS GOARCH=$$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w   -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.Model=$(MODEL) -X main.ApiKey=$(API_KEY) -X main.ApiUrl=$(API_URL)" -o "$$OUTPUT_FILE" .; \
+		upx -9 "$$OUTPUT_FILE"; \
+	done
+
 # 清理生成的可执行文件
 .PHONY: clean
 clean:
@@ -141,6 +167,7 @@ help:
 	@echo "可用的目标:"
 	@echo "  docker      构建容器镜像 (使用 BUILD_TOOL 指定的构建工具，默认为 podman)"
 	@echo "  build       为当前平台构建可执行文件"
+	@echo "  build-linux 为Linux平台构建可执行文件"
 	@echo "  build-all   为所有平台构建可执行文件"
 	@echo "  clean       清理生成的可执行文件"
 	@echo "  run         运行当前平台的可执行文件"


### PR DESCRIPTION
需要在仓库增加两个秘钥：

```
ALIHUB_TOKEN
DOCKERHUB_TOKEN
```

第二：需要修改docker仓库的几个信息：

<img width="462" alt="image" src="https://github.com/user-attachments/assets/aa6f253e-d4c0-4965-845f-1c363c84012c" />

然后提交之后，会自动构建docker镜像，每次提交，或者pr都会自动构建release的草稿，感觉需要发布版本，可以点击编辑release草稿，没问题之后，点击发布，自动触发流水线，将对应版本的二进制发布到release中。

<img width="918" alt="image" src="https://github.com/user-attachments/assets/41f9ca6a-fcf5-493d-826e-f95d3d8dca73" />

目前还存在的问题：
1. docker镜像目前只构建了linux-amd64，比较奇怪arm64构建会卡住，提了个issue，后续关注一下。见：https://github.com/docker/build-push-action/issues/1348
2. 目前二进制构建使用的makefile，属于串行，因此整体构建下来要十八分钟，但压缩效果比较理想。我也换了：https://github.com/wangyoucao577/go-release-action 构建，看了下这个仓库使用的upx是v4.0的，压缩之后，会比makefile打出来的体积大一倍。故而暂时放弃。但这种方式是并发构建，整体打完大概五分钟左右。后续看看完全自定义构建命令，然后并发构建，应该会提升很多。
3. github action强大归强大，调试还是比较费劲儿的。
