### PR TITLE
feat: 添加AI功能开关配置

### DIFF
--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -42,6 +42,7 @@ type Config struct {
 	GitTag            string // git tag, 由编译时自动注入
 	GitRepo           string // git仓库地址, 由编译时自动注入
 	BuildDate         string // 编译时间, 由编译时自动注入
+	EnableAI          bool   // 是否启用AI功能，默认开启
 }
 
 func Init() *Config {
@@ -124,6 +125,8 @@ func (c *Config) InitFlags() {
 
 	// 默认不打印配置
 	defaultPrintConfig := getEnvAsBool("PRINT_CONFIG", false)
+	// 默认开启AI功能
+	defaultEnableAI := getEnvAsBool("ENABLE_AI", true)
 
 	pflag.BoolVarP(&c.Debug, "debug", "d", defaultDebug, "调试模式")
 	pflag.IntVarP(&c.Port, "port", "p", defaultPort, "监听端口,默认3618")
@@ -143,6 +146,7 @@ func (c *Config) InitFlags() {
 	pflag.IntVarP(&c.MCPServerPort, "mcp-server-port", "s", defaultMCPServerPort, "MCP Server 监听端口，默认3619")
 	pflag.BoolVar(&c.AnySelect, "any-select", defaultAnySelect, "是否开启任意选择，默认开启")
 	pflag.BoolVar(&c.PrintConfig, "print-config", defaultPrintConfig, "是否打印配置信息，默认关闭")
+	pflag.BoolVar(&c.EnableAI, "enable-ai", defaultEnableAI, "是否启用AI功能，默认开启")
 
 	// 检查是否设置了 --v 参数
 	if vFlag := pflag.Lookup("v"); vFlag == nil || vFlag.Value.String() == "0" {

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	SqlitePath        string    `json:"sqlite_path,omitempty"`
 	AnySelect         bool      `json:"any_select,omitempty"`
 	PrintConfig       bool      `json:"print_config,omitempty"`
+	EnableAI          bool      `json:"enable_ai,omitempty"`  // 是否启用AI功能，默认开启
 	CreatedAt         time.Time `json:"created_at,omitempty"` // Automatically managed by GORM for creation time
 	UpdatedAt         time.Time `json:"updated_at,omitempty"` // Automatically managed by GORM for update time
 }

--- a/pkg/service/config.go
+++ b/pkg/service/config.go
@@ -82,6 +82,7 @@ func (s *configService) UpdateFlagFromDBConfig() error {
 	}
 
 	cfg.PrintConfig = m.PrintConfig
+	cfg.EnableAI = m.EnableAI
 
 	// JwtTokenSecret 暂不启用，因为前端也要处理
 	// cfg.JwtTokenSecret = m.JwtTokenSecret

--- a/ui/public/pages/admin/config/config.json
+++ b/ui/public/pages/admin/config/config.json
@@ -71,6 +71,13 @@
                                     "title": "AI配置",
                                     "body": [
                                         {
+                                            "name": "enable_ai",
+                                            "type": "switch",
+                                            "label": "AI功能开关",
+                                            "value": true,
+                                            "desc": "是否启用AI功能，默认开启"
+                                        },
+                                        {
                                             "name": "api_url",
                                             "type": "input-url",
                                             "label": "API地址",


### PR DESCRIPTION
在配置服务、模型、前端页面和命令行标志中添加了AI功能开关配置，默认开启。这使得管理员能够通过UI界面或命令行参数控制AI功能的启用状态。