### PR TITLE
refactor(admin/mcp): 移除自动生成过滤器并添加名称列搜索功能

### DIFF
--- a/ui/public/pages/admin/mcp/mcp.json
+++ b/ui/public/pages/admin/mcp/mcp.json
@@ -193,10 +193,6 @@
                       "autoFillHeight": true,
                       "api": "get:/admin/mcp/server/${name}/tools/list",
                       "quickSaveItemApi": "/admin/mcp/tool/save/id/${id}/status/${enabled}",
-                      "autoGenerateFilter": {
-                        "columnsNum": 4,
-                        "showBtnToolbar": false
-                      },
                       "headerToolbar": [
                         {
                           "type": "columns-toggler",
@@ -226,6 +222,14 @@
                         {
                           "name": "name",
                           "label": "名称",
+                          "sortable": true,
+                          "searchable": {
+                            "type": "input-text",
+                            "name": "name",
+                            "label": "工具名称",
+                            "placeholder": "输入工具名称",
+                            "width": "200px"
+                          },
                           "type": "tpl",
                           "tpl": "${name}<br><span class='text-muted'>${description}</span>"
                         },


### PR DESCRIPTION
移除`autoGenerateFilter`配置，简化表格过滤器设置。同时为名称列添加排序和搜索功能，提升用户查找工具的体验。