### PR TITLE
fix(ui): 修复实时用量显示逻辑，避免无效数据展示

### DIFF
--- a/ui/public/pages/cluster/node.json
+++ b/ui/public/pages/cluster/node.json
@@ -1110,7 +1110,7 @@
           "name": "realtime",
           "label": "实时用量<br><span class='text-gray-500 text-xs'>CPU(m毫核)/内存(Mi)</span>",
           "type": "tpl",
-          "tpl": "<%= (data.metadata.annotations['cpu.realtime'] ? data.metadata.annotations['cpu.realtime']  : 'N/A') + ' / ' + (data.metadata.annotations['memory.realtime'] ? data.metadata.annotations['memory.realtime'] : 'N/A') %>"
+          "tpl": "<%= ( data.metadata.annotations && data.metadata.annotations['cpu.realtime'] && Number(data.metadata.annotations['cpu.realtime']) !== 0 ? data.metadata.annotations['cpu.realtime']  : 'N/A') + ' / ' + (data.metadata.annotations && data.metadata.annotations['memory.realtime'] && Number(data.metadata.annotations['memory.realtime']) !== 0? data.metadata.annotations['memory.realtime'] : 'N/A') %>"
         },
         {
           "name": "resource",

--- a/ui/public/pages/ns/pod.json
+++ b/ui/public/pages/ns/pod.json
@@ -3051,7 +3051,7 @@
           "name": "realtime",
           "label": "实时用量<br><span class='text-gray-500 text-xs'>CPU(m毫核)/内存(Mi)</span>",
           "type": "tpl",
-          "tpl": "<%= (data.metadata.annotations['cpu.realtime'] ? data.metadata.annotations['cpu.realtime']  : 'N/A') + ' / ' + (data.metadata.annotations['memory.realtime'] ? data.metadata.annotations['memory.realtime'] : 'N/A') %>"
+          "tpl": "<%= ( data.metadata.annotations && data.metadata.annotations['cpu.realtime'] && Number(data.metadata.annotations['cpu.realtime']) !== 0 ? data.metadata.annotations['cpu.realtime']  : 'N/A') + ' / ' + (data.metadata.annotations && data.metadata.annotations['memory.realtime'] && Number(data.metadata.annotations['memory.realtime']) !== 0? data.metadata.annotations['memory.realtime'] : 'N/A') %>"
         },
         {
           "name": "资源设定",


### PR DESCRIPTION
在 pod.json 和 node.json 中，更新了实时用量的模板逻辑，确保仅在 annotations 存在且数值不为 0 时显示具体数值，否则显示 'N/A'。这避免了无效或缺失数据的错误展示。