### PR TITLE
feat: 添加MCP工具调用日志记录和临时管理员角色支持

### DIFF
--- a/mcp_start.go
+++ b/mcp_start.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
+	mcp2 "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/weibaohui/k8m/pkg/comm/utils"
 	"github.com/weibaohui/k8m/pkg/constants"
+	mcp3 "github.com/weibaohui/k8m/pkg/mcp"
 	"github.com/weibaohui/k8m/pkg/service"
 	"github.com/weibaohui/kom/mcp"
 	"github.com/weibaohui/kom/mcp/metadata"
@@ -31,6 +35,46 @@ func MCPStart(version string, port int) {
 
 		return newCtx
 	}
+
+	var errFn = func(ctx context.Context, id any, method mcp2.MCPMethod, message any, err error) {
+		if request, ok := message.(*mcp2.CallToolRequest); ok {
+			errStr := fmt.Sprintf("%v", err)
+			host := service.McpService().Host()
+			toolName := request.Params.Name
+			serverName := host.GetServerNameByToolName(toolName)
+			parameters := request.Params.Arguments
+			resultInfo := mcp3.ToolCallResult{
+				ToolName:   toolName,
+				Parameters: parameters,
+				Result:     errStr,
+				Error:      errStr,
+			}
+			host.LogToolExecution(ctx, toolName, serverName, parameters, resultInfo, 1)
+		}
+	}
+	var actFn = func(ctx context.Context, id any, request *mcp2.CallToolRequest, result *mcp2.CallToolResult) {
+		host := service.McpService().Host()
+		toolName := request.Params.Name
+		serverName := host.GetServerNameByToolName(toolName)
+		parameters := request.Params.Arguments
+		var resultStr string
+		var errStr string
+		resultStr = utils.ToJSON(resultStr)
+		if result.IsError {
+			errStr = resultStr
+		}
+		resultInfo := mcp3.ToolCallResult{
+			ToolName:   toolName,
+			Parameters: parameters,
+			Result:     resultStr,
+			Error:      errStr,
+		}
+		host.LogToolExecution(ctx, toolName, serverName, parameters, resultInfo, 1)
+	}
+	hooks := &server.Hooks{
+		OnError:         []server.OnErrorHookFunc{errFn},
+		OnAfterCallTool: []server.OnAfterCallToolFunc{actFn},
+	}
 	cfg := metadata.ServerConfig{
 		Name:    "k8m mcp server",
 		Version: version,
@@ -39,6 +83,7 @@ func MCPStart(version string, port int) {
 			server.WithResourceCapabilities(false, false),
 			server.WithPromptCapabilities(false),
 			server.WithLogging(),
+			server.WithHooks(hooks),
 		},
 		SSEOption: []server.SSEOption{
 			server.WithSSEPattern("/:channel/sse"),

--- a/pkg/mcp/mcp_log.go
+++ b/pkg/mcp/mcp_log.go
@@ -37,7 +37,7 @@ func (m *MCPHost) LogToolExecution(ctx context.Context, toolName, serverName str
 	dao.DB().Create(log)
 }
 
-func (m *MCPHost) addLog(log *models.MCPToolLog) {
+func (m *MCPHost) AddLog(log *models.MCPToolLog) {
 
 	m.bufferMux.Lock()
 	m.buffer = append(m.buffer, log)

--- a/pkg/service/user.go
+++ b/pkg/service/user.go
@@ -248,6 +248,10 @@ func (u *userService) CheckAndCreateUser(username, source string) error {
 
 // GetPlatformRolesByName 通过用户名获取用户的平台角色
 func (u *userService) GetPlatformRolesByName(username string) string {
+	cfg := flag.Init()
+	if cfg.EnableTempAdmin && username == cfg.AdminUserName {
+		return constants.RolePlatformAdmin
+	}
 	if names, err := u.GetGroupNames(username); err == nil {
 		if rolesByGroupNames, err := u.GetRolesByGroupNames(names); err == nil {
 			return strings.Join(rolesByGroupNames, ",")


### PR DESCRIPTION
在MCP工具调用时，添加错误和成功日志记录功能，方便追踪工具执行情况。同时，在用户服务中增加临时管理员角色支持，当配置启用时，特定用户将被赋予平台管理员角色。