### PR TITLE
fix(用户配置): 更新SSE URL模板以使用动态主机地址

### DIFF
--- a/ui/public/pages/user/profile/mcp_keys.json
+++ b/ui/public/pages/user/profile/mcp_keys.json
@@ -71,7 +71,7 @@
           "body": [
             {
               "type": "tpl",
-              "tpl": "http://localhost:3619/${key}/sse"
+              "tpl": "<%= 'http://' + window.location.host %>/<%= data.key%>/sse"
             }
           ]
         },


### PR DESCRIPTION
修复SSE URL模板，使其不再硬编码localhost，而是动态获取当前主机地址，确保在不同环境中正确生成URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the access link in the user profile page to dynamically use the current host, ensuring correct link generation across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->