### PR TITLE
fix: 修复GetSelectedCluster错误处理，确保返回错误时中断操作

### DIFF
--- a/pkg/comm/utils/amis/gin.go
+++ b/pkg/comm/utils/amis/gin.go
@@ -3,17 +3,22 @@ package amis
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/duke-git/lancet/v2/slice"
 	"github.com/gin-gonic/gin"
 	"github.com/weibaohui/k8m/pkg/constants"
 	"github.com/weibaohui/k8m/pkg/models"
+	"github.com/weibaohui/kom/kom"
 )
 
-func GetSelectedCluster(c *gin.Context) string {
+func GetSelectedCluster(c *gin.Context) (string, error) {
 	selectedCluster := c.GetString("cluster")
-	return selectedCluster
+	if kom.Cluster(selectedCluster) == nil {
+		return "", fmt.Errorf("cluster %s not found", selectedCluster)
+	}
+	return selectedCluster, nil
 }
 
 // GetLoginUserClusters 获取当前登录用户可访问集群列表

--- a/pkg/controller/admin/user/user_group.go
+++ b/pkg/controller/admin/user/user_group.go
@@ -69,7 +69,7 @@ func DeleteUserGroup(c *gin.Context) {
 }
 
 func handleCommonLogic(c *gin.Context, action string, groupName string) (string, string, error) {
-	cluster := amis.GetSelectedCluster(c)
+	cluster, _ := amis.GetSelectedCluster(c)
 	ctx := amis.GetContextWithUser(c)
 	username := fmt.Sprintf("%s", ctx.Value(constants.JwtUserName))
 	role := fmt.Sprintf("%s", ctx.Value(constants.JwtUserRole))

--- a/pkg/controller/chat/chat.go
+++ b/pkg/controller/chat/chat.go
@@ -84,8 +84,13 @@ func Describe(c *gin.Context) {
 		amis.WriteJsonError(c, err)
 		return
 	}
+	cluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	var describe []byte
-	kom.Cluster(amis.GetSelectedCluster(c)).WithContext(ctx).GVK(data.Group, data.Version, data.Kind).
+	kom.Cluster(cluster).WithContext(ctx).GVK(data.Group, data.Version, data.Kind).
 		Name(data.Name).
 		Namespace(data.Namespace).
 		Describe(&describe)

--- a/pkg/controller/cm/cm.go
+++ b/pkg/controller/cm/cm.go
@@ -25,7 +25,11 @@ func Import(c *gin.Context) {
 	info := &info{}
 	ns := c.Param("ns")
 	name := c.Param("name")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	ctx := amis.GetContextWithUser(c)
 	info.FileName = c.PostForm("fileName")
 
@@ -79,7 +83,11 @@ func Update(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	key := c.Param("key")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	ctx := amis.GetContextWithUser(c)
 	// 解析JSON请求体
 	var requestBody struct {
@@ -95,7 +103,7 @@ func Update(c *gin.Context) {
 		return
 	}
 	var cm *v1.ConfigMap
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ConfigMap{}).Name(name).Namespace(ns).Get(&cm).Error
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ConfigMap{}).Name(name).Namespace(ns).Get(&cm).Error
 	if err != nil {
 		amis.WriteJsonError(c, fmt.Errorf("获取configmap错误: %v", err))
 		return
@@ -126,7 +134,11 @@ func Update(c *gin.Context) {
 // Create 创建configmap接口
 func Create(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	// 解析请求体
 	var requestBody struct {
 		Metadata struct {
@@ -143,7 +155,7 @@ func Create(c *gin.Context) {
 	}
 	// 判断是否存在同名ConfigMap
 	var existingCM v1.ConfigMap
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ConfigMap{}).Name(requestBody.Metadata.Name).Namespace(requestBody.Metadata.Namespace).Get(&existingCM).Error
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ConfigMap{}).Name(requestBody.Metadata.Name).Namespace(requestBody.Metadata.Namespace).Get(&existingCM).Error
 	if err == nil {
 		amis.WriteJsonError(c, fmt.Errorf("ConfigMap %s 已存在", requestBody.Metadata.Name))
 		return

--- a/pkg/controller/cronjob/cronjob.go
+++ b/pkg/controller/cronjob/cronjob.go
@@ -12,9 +12,13 @@ func Pause(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.CronJob{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.CronJob{}).Namespace(ns).Name(name).
 		Ctl().CronJob().Pause()
 	amis.WriteJsonErrorOrOK(c, err)
 }
@@ -22,16 +26,24 @@ func Resume(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.CronJob{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.CronJob{}).Namespace(ns).Name(name).
 		Ctl().CronJob().Resume()
 	amis.WriteJsonErrorOrOK(c, err)
 }
 
 func BatchResume(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -42,7 +54,6 @@ func BatchResume(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -64,18 +75,21 @@ func BatchResume(c *gin.Context) {
 
 func BatchPause(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
 		Namespaces []string `json:"ns_list"`
 	}
-	if err := c.ShouldBindJSON(&req); err != nil {
+	if err = c.ShouldBindJSON(&req); err != nil {
 		amis.WriteJsonError(c, err)
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]

--- a/pkg/controller/deploy/deploy.go
+++ b/pkg/controller/deploy/deploy.go
@@ -19,7 +19,11 @@ import (
 
 func BatchStop(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -30,7 +34,6 @@ func BatchStop(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -51,7 +54,11 @@ func BatchStop(c *gin.Context) {
 }
 func BatchRestore(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -62,7 +69,6 @@ func BatchRestore(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -85,15 +91,23 @@ func Restart(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Restart()
 	amis.WriteJsonErrorOrOK(c, err)
 }
 func BatchRestart(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -104,7 +118,6 @@ func BatchRestart(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -127,7 +140,11 @@ func History(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	list, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
 		Ctl().Rollout().History()
@@ -142,7 +159,11 @@ func HistoryRevisionDiff(c *gin.Context) {
 	name := c.Param("name")
 	revision := c.Param("revision")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	// 找到最新的rs
 	rsLatest, err := kom.Cluster(selectedCluster).WithContext(ctx).
@@ -180,9 +201,13 @@ func Pause(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Pause()
 	amis.WriteJsonErrorOrOK(c, err)
 }
@@ -190,9 +215,13 @@ func Resume(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Resume()
 	amis.WriteJsonErrorOrOK(c, err)
 }
@@ -203,9 +232,13 @@ func Scale(c *gin.Context) {
 	r := utils.ToInt32(replica)
 
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
 		Ctl().Scaler().Scale(r)
 	amis.WriteJsonErrorOrOK(c, err)
 }
@@ -215,7 +248,11 @@ func Undo(c *gin.Context) {
 	revision := c.Param("revision")
 	ctx := amis.GetContextWithUser(c)
 	r := utils.ToInt(revision)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	result, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Undo(r)
@@ -231,7 +268,11 @@ func Event(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var metas []string
 
@@ -291,7 +332,11 @@ func HPA(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	hpa, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Namespace(ns).Name(name).
 		Ctl().Deployment().HPAList()
 	if err != nil {
@@ -304,7 +349,11 @@ func HPA(c *gin.Context) {
 // 创建deployment
 func Create(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Metadata struct {
@@ -333,7 +382,7 @@ func Create(c *gin.Context) {
 	}
 	// 判断是否存在同名Deployment
 	var existingDeployment v1.Deployment
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Name(req.Metadata.Name).Namespace(req.Metadata.Namespace).Get(&existingDeployment).Error
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Deployment{}).Name(req.Metadata.Name).Namespace(req.Metadata.Namespace).Get(&existingDeployment).Error
 	if err == nil {
 		amis.WriteJsonError(c, fmt.Errorf("Deployment %s 已存在", req.Metadata.Name))
 		return

--- a/pkg/controller/doc/doc.go
+++ b/pkg/controller/doc/doc.go
@@ -15,12 +15,15 @@ func Doc(c *gin.Context) {
 	apiVersion := c.Param("api_version")
 	group := c.Param("group")
 	version := c.Param("version")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	ctx := amis.GetContextWithUser(c)
 
 	// apiVersion 有可能包含xxx.com/v1 类似，所以需要处理
 	// 前端使用了base64Encode，这里需要反向解析处理
-	var err error
 	if apiVersion != "" {
 		apiVersion, err = utils.DecodeBase64(apiVersion)
 		if err != nil {

--- a/pkg/controller/ds/ds.go
+++ b/pkg/controller/ds/ds.go
@@ -13,7 +13,11 @@ func History(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	list, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.DaemonSet{}).Namespace(ns).Name(name).
 		Ctl().Rollout().History()
@@ -27,16 +31,24 @@ func Restart(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.DaemonSet{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.DaemonSet{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Restart()
 	amis.WriteJsonErrorOrOK(c, err)
 }
 
 func BatchRestart(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -47,7 +59,6 @@ func BatchRestart(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -72,7 +83,11 @@ func Undo(c *gin.Context) {
 	revision := c.Param("revision")
 	ctx := amis.GetContextWithUser(c)
 	r := utils.ToInt(revision)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	result, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.DaemonSet{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Undo(r)
@@ -85,7 +100,11 @@ func Undo(c *gin.Context) {
 
 func BatchStop(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -96,7 +115,6 @@ func BatchStop(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -117,7 +135,11 @@ func BatchStop(c *gin.Context) {
 }
 func BatchRestore(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -128,7 +150,6 @@ func BatchRestore(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]

--- a/pkg/controller/dynamic/annotation.go
+++ b/pkg/controller/dynamic/annotation.go
@@ -46,7 +46,11 @@ func UpdateAnnotations(c *gin.Context) {
 	group := c.Param("group")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Annotations map[string]interface{} `json:"annotations"`
@@ -72,7 +76,7 @@ func UpdateAnnotations(c *gin.Context) {
 		return
 	}
 	var obj *unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Name(name).Namespace(ns).
 		CRD(group, version, kind).
 		Get(&obj).Error
@@ -106,10 +110,14 @@ func ListAnnotations(c *gin.Context) {
 	group := c.Param("group")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var obj *unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Name(name).Namespace(ns).
 		CRD(group, version, kind).
 		Get(&obj).Error

--- a/pkg/controller/dynamic/container.go
+++ b/pkg/controller/dynamic/container.go
@@ -21,10 +21,14 @@ func ImagePullSecretOptionList(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var item *unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).
 		Name(name).Get(&item).Error
@@ -73,10 +77,14 @@ func ContainerResourcesInfo(c *gin.Context) {
 	version := c.Param("version")
 	containerName := c.Param("container_name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var item *unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).
 		Name(name).Get(&item).Error
@@ -214,7 +222,11 @@ func UpdateResources(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var info resourceInfo
 
@@ -305,10 +317,14 @@ func ContainerInfo(c *gin.Context) {
 	version := c.Param("version")
 	containerName := c.Param("container_name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var item *unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).
 		Name(name).Get(&item).Error
@@ -342,10 +358,14 @@ func ContainerEnvInfo(c *gin.Context) {
 	version := c.Param("version")
 	containerName := c.Param("container_name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var item *unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).
 		Name(name).Get(&item).Error
@@ -379,7 +399,11 @@ func UpdateContainerEnv(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var info ContainerEnv
 	if err := c.ShouldBindJSON(&info); err != nil {
@@ -651,7 +675,11 @@ func UpdateImageTag(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var info imageInfo
 
@@ -729,10 +757,14 @@ func ContainerHealthChecksInfo(c *gin.Context) {
 	version := c.Param("version")
 	containerName := c.Param("container_name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var item *unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).
 		Name(name).Get(&item).Error
@@ -825,7 +857,11 @@ func UpdateHealthChecks(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var info HealthCheckInfo
 	if err := c.ShouldBindJSON(&info); err != nil {

--- a/pkg/controller/dynamic/crd_option.go
+++ b/pkg/controller/dynamic/crd_option.go
@@ -13,7 +13,11 @@ import (
 
 func GroupOptionList(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	groups := getCrdGroupList(ctx, selectedCluster)
 	var options []map[string]string
@@ -31,7 +35,11 @@ func GroupOptionList(c *gin.Context) {
 
 func KindOptionList(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	g := c.Query("spec[group]")
 	if g == "" {
 		// 还没选group
@@ -69,7 +77,11 @@ type CrdTree struct {
 // Deprecated: 废弃，请不要使用
 func CrdGuidTreeThree(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	list, err := getCrdList(ctx, selectedCluster)
 
@@ -147,7 +159,11 @@ func CrdGuidTreeThree(c *gin.Context) {
 // Deprecated: 废弃，请不要使用
 func CrdGuidTree(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	groups := getCrdGroupList(ctx, selectedCluster)
 	var crdTreeList []*CrdTree

--- a/pkg/controller/dynamic/label.go
+++ b/pkg/controller/dynamic/label.go
@@ -14,7 +14,11 @@ func UpdateLabels(c *gin.Context) {
 	group := c.Param("group")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Labels map[string]string `json:"labels"`
@@ -25,7 +29,7 @@ func UpdateLabels(c *gin.Context) {
 	}
 
 	var obj *unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Name(name).Namespace(ns).
 		CRD(group, version, kind).
 		Get(&obj).Error

--- a/pkg/controller/dynamic/node_affinity.go
+++ b/pkg/controller/dynamic/node_affinity.go
@@ -27,11 +27,15 @@ func ListNodeAffinity(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	// 先获取资源中的定义
 	var item unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).
+	err = kom.Cluster(selectedCluster).
 		WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).Name(name).
@@ -110,7 +114,11 @@ func processNodeAffinity(c *gin.Context, action string) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var info nodeAffinity
 
@@ -128,7 +136,7 @@ func processNodeAffinity(c *gin.Context, action string) {
 
 	// 先获取资源中的定义
 	var item unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).
+	err = kom.Cluster(selectedCluster).
 		WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).Name(name).

--- a/pkg/controller/dynamic/pod_affinity.go
+++ b/pkg/controller/dynamic/pod_affinity.go
@@ -30,11 +30,15 @@ func ListPodAffinity(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	// 先获取资源中的定义
 	var item unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).
+	err = kom.Cluster(selectedCluster).
 		WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).Name(name).
@@ -88,7 +92,11 @@ func processPodAffinity(c *gin.Context, action string) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var info podAffinity
 
@@ -99,7 +107,7 @@ func processPodAffinity(c *gin.Context, action string) {
 
 	// 先获取资源中的定义
 	var item unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).
+	err = kom.Cluster(selectedCluster).
 		WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).Name(name).

--- a/pkg/controller/dynamic/pod_anti_affinity.go
+++ b/pkg/controller/dynamic/pod_anti_affinity.go
@@ -22,11 +22,15 @@ func ListPodAntiAffinity(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	// 先获取资源中的定义
 	var item unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).
+	err = kom.Cluster(selectedCluster).
 		WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).Name(name).
@@ -80,7 +84,11 @@ func processPodAntiAffinity(c *gin.Context, action string) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var info podAffinity
 
@@ -91,7 +99,7 @@ func processPodAntiAffinity(c *gin.Context, action string) {
 
 	// 先获取资源中的定义
 	var item unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).
+	err = kom.Cluster(selectedCluster).
 		WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).Name(name).

--- a/pkg/controller/dynamic/pod_link.go
+++ b/pkg/controller/dynamic/pod_link.go
@@ -60,7 +60,11 @@ func LinksServices(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -81,7 +85,11 @@ func LinksEndpoints(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -104,7 +112,11 @@ func LinksPVC(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -125,7 +137,11 @@ func LinksPV(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -146,7 +162,11 @@ func LinksIngress(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -167,7 +187,11 @@ func LinksEnv(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -188,7 +212,11 @@ func LinksEnvFromPod(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -209,7 +237,11 @@ func LinksConfigMap(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -230,7 +262,11 @@ func LinksSecret(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -251,7 +287,11 @@ func LinksNode(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	pod, err := getPod(selectedCluster, ctx, ns, name, kind)
 
@@ -271,7 +311,11 @@ func LinksPod(c *gin.Context) {
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
 	kind := c.Param("kind")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	pods, err := getPods(selectedCluster, ctx, ns, name, kind)
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/dynamic/toleration.go
+++ b/pkg/controller/dynamic/toleration.go
@@ -28,11 +28,15 @@ func ListTolerations(c *gin.Context) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	// 先获取资源中的定义
 	var item unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).
+	err = kom.Cluster(selectedCluster).
 		WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).Name(name).
@@ -86,7 +90,11 @@ func processTolerations(c *gin.Context, action string) {
 	kind := c.Param("kind")
 	version := c.Param("version")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var info Tolerations
 
@@ -102,7 +110,7 @@ func processTolerations(c *gin.Context, action string) {
 
 	// 先获取资源中的定义
 	var item unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).
+	err = kom.Cluster(selectedCluster).
 		WithContext(ctx).
 		CRD(group, version, kind).
 		Namespace(ns).Name(name).

--- a/pkg/controller/helm/helm.go
+++ b/pkg/controller/helm/helm.go
@@ -16,14 +16,18 @@ func getHelm(c *gin.Context, namespace string) (helm.Helm, error) {
 	// if namespace == "" {
 	// 	namespace = "default"
 	// }
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return nil, err
+	}
 	restConfig := service.ClusterService().GetClusterByID(selectedCluster).GetRestConfig()
 	h, err := helm.New(restConfig, namespace)
 	return h, err
 }
 
 func handleCommonLogic(c *gin.Context, action string, releaseName, namespace, repoName string) (string, string, error) {
-	cluster := amis.GetSelectedCluster(c)
+	cluster, _ := amis.GetSelectedCluster(c)
 	ctx := amis.GetContextWithUser(c)
 	username := fmt.Sprintf("%s", ctx.Value(constants.JwtUserName))
 	role := fmt.Sprintf("%s", ctx.Value(constants.JwtUserRole))

--- a/pkg/controller/ingressclass/ingress_class.go
+++ b/pkg/controller/ingressclass/ingress_class.go
@@ -11,9 +11,13 @@ import (
 func SetDefault(c *gin.Context) {
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Resource(&v1.IngressClass{}).Name(name).
 		Ctl().IngressClass().SetDefault()
 	if err != nil {
@@ -25,10 +29,14 @@ func SetDefault(c *gin.Context) {
 
 func OptionList(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var list []v1.IngressClass
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.IngressClass{}).List(&list).Error
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.IngressClass{}).List(&list).Error
 	if err != nil {
 		amis.WriteJsonData(c, gin.H{
 			"options": make([]map[string]string, 0),

--- a/pkg/controller/k8sgpt/k8sgpt.go
+++ b/pkg/controller/k8sgpt/k8sgpt.go
@@ -15,7 +15,11 @@ import (
 )
 
 func GetFields(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	kind := "Deployment"
 	apiDoc := kubernetes.K8sApiReference{

--- a/pkg/controller/node/node.go
+++ b/pkg/controller/node/node.go
@@ -16,25 +16,37 @@ import (
 func Drain(c *gin.Context) {
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
 		Ctl().Node().Drain()
 	amis.WriteJsonErrorOrOK(c, err)
 }
 func Cordon(c *gin.Context) {
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
 		Ctl().Node().Cordon()
 	amis.WriteJsonErrorOrOK(c, err)
 }
 func Usage(c *gin.Context) {
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	usage, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
 		Ctl().Node().ResourceUsageTable()
@@ -48,16 +60,24 @@ func Usage(c *gin.Context) {
 func UnCordon(c *gin.Context) {
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
 		Ctl().Node().UnCordon()
 	amis.WriteJsonErrorOrOK(c, err)
 }
 
 func BatchDrain(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names []string `json:"name_list"`
@@ -67,7 +87,6 @@ func BatchDrain(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		x := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
@@ -87,7 +106,11 @@ func BatchDrain(c *gin.Context) {
 
 func BatchCordon(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names []string `json:"name_list"`
@@ -97,7 +120,6 @@ func BatchCordon(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		x := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
@@ -117,7 +139,11 @@ func BatchCordon(c *gin.Context) {
 
 func BatchUnCordon(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names []string `json:"name_list"`
@@ -127,7 +153,6 @@ func BatchUnCordon(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		x := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
@@ -147,10 +172,14 @@ func BatchUnCordon(c *gin.Context) {
 
 func NameOptionList(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var list []unstructured.Unstructured
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).
 		WithCache(time.Second * 30).
 		List(&list).Error
 	if err != nil {
@@ -182,7 +211,11 @@ func NameOptionList(c *gin.Context) {
 // AllLabelList 获取所有节点上的标签
 func AllLabelList(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	// 先拿到所有的lable列表
 	// 通过lable的kv去匹配node，将node name放入到label 结构体中，方便选择时做出判断
 	labels, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).
@@ -234,10 +267,14 @@ func AllLabelList(c *gin.Context) {
 // AllTaintList 获取所有节点上的污点
 func AllTaintList(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var nodeList []*v1.Node
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).
 		WithCache(time.Second * 30).
 		List(&nodeList).Error
 	if err != nil {
@@ -291,7 +328,11 @@ func AllTaintList(c *gin.Context) {
 	amis.WriteJsonList(c, resultList)
 }
 func UniqueLabels(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	labels := service.NodeService().GetUniqueLabels(selectedCluster)
 

--- a/pkg/controller/node/taint.go
+++ b/pkg/controller/node/taint.go
@@ -13,10 +13,14 @@ import (
 func ListTaint(c *gin.Context) {
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var node v1.Node
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Node{}).Name(name).
 		Get(&node).Error
 	if err != nil {
 		amis.WriteJsonError(c, err)
@@ -62,10 +66,13 @@ func UpdateTaint(c *gin.Context) {
 func processTaint(c *gin.Context, mode string) error {
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		return err
+	}
 
 	var info TaintInfo
-	err := c.ShouldBindJSON(&info)
+	err = c.ShouldBindJSON(&info)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/node/xterm.go
+++ b/pkg/controller/node/xterm.go
@@ -24,7 +24,11 @@ var WebsocketMessageType = map[int]string{
 
 func CreateNodeShell(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	name := c.Param("node_name") // NodeName
 	cfg := flag.Init()
 	timeout := cfg.ImagePullTimeout

--- a/pkg/controller/ns/limit_range.go
+++ b/pkg/controller/ns/limit_range.go
@@ -15,7 +15,11 @@ import (
 
 func CreateLimitRange(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var data struct {
 		Name     string `json:"name"`
@@ -69,7 +73,7 @@ func CreateLimitRange(c *gin.Context) {
 						return
 					}
 				}
-				
+
 				if name == "cpu" {
 					value = fmt.Sprintf("%sm", value)
 				}
@@ -93,7 +97,7 @@ func CreateLimitRange(c *gin.Context) {
 						return
 					}
 				}
-				
+
 				if name == "cpu" {
 					value = fmt.Sprintf("%sm", value)
 				}
@@ -118,7 +122,7 @@ func CreateLimitRange(c *gin.Context) {
 					return
 				}
 			}
-			
+
 			if name == "cpu" {
 				value = fmt.Sprintf("%sm", value)
 			}
@@ -142,7 +146,7 @@ func CreateLimitRange(c *gin.Context) {
 					return
 				}
 			}
-			
+
 			if name == "cpu" {
 				value = fmt.Sprintf("%sm", value)
 			}
@@ -160,7 +164,7 @@ func CreateLimitRange(c *gin.Context) {
 		limitRange.Spec.Limits = append(limitRange.Spec.Limits, limitItem)
 	}
 	klog.Infof("limitRange: %v", utils.ToJSON(limitRange))
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Resource(limitRange).
 		Name(data.Name).
 		Namespace(data.Metadata.Namespace).

--- a/pkg/controller/ns/ns.go
+++ b/pkg/controller/ns/ns.go
@@ -14,7 +14,11 @@ import (
 )
 
 func OptionList(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	// 处理集群中有限制namespace的情况
 	if list, ok := handleRestrictedNamespace(selectedCluster); ok {

--- a/pkg/controller/ns/resource_quota.go
+++ b/pkg/controller/ns/resource_quota.go
@@ -14,8 +14,11 @@ import (
 
 func CreateResourceQuota(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
-
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	var data struct {
 		Name     string `json:"name"`
 		Metadata struct {
@@ -135,7 +138,7 @@ func CreateResourceQuota(c *gin.Context) {
 		}
 	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Resource(quota).
 		Name(data.Name).
 		Namespace(data.Metadata.Namespace).

--- a/pkg/controller/pod/pod.go
+++ b/pkg/controller/pod/pod.go
@@ -32,10 +32,14 @@ func StreamLogs(c *gin.Context) {
 }
 func StreamPodLogsBySelector(c *gin.Context, ns string, containerName string, options metav1.ListOptions) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var pods []v1.Pod
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Pod{}).Namespace(ns).List(&pods, options).Error
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Pod{}).Namespace(ns).List(&pods, options).Error
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -76,7 +80,11 @@ func WsExec(c *gin.Context) {
 	containerName := c.Param("container_name")
 	cmd := c.Query("cmd")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	if cmd == "" {
 		amis.WriteJsonError(c, fmt.Errorf("执行命令为空"))
@@ -128,7 +136,11 @@ func Exec(c *gin.Context) {
 	podName := c.Param("pod_name")
 	containerName := c.Param("container_name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second*5))
 	defer cancel()
@@ -160,7 +172,7 @@ func Exec(c *gin.Context) {
 	}
 
 	var result []byte
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Resource(&v1.Pod{}).
 		Namespace(ns).
 		Name(podName).Ctl().Pod().
@@ -182,11 +194,15 @@ func Exec(c *gin.Context) {
 
 }
 func DownloadPodLogsBySelector(c *gin.Context, ns string, containerName string, options metav1.ListOptions) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	ctx := amis.GetContextWithUser(c)
 	var pods []v1.Pod
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Pod{}).Namespace(ns).List(&pods, options).Error
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.Pod{}).Namespace(ns).List(&pods, options).Error
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -217,7 +233,11 @@ func Usage(c *gin.Context) {
 	name := c.Param("name")
 	ns := c.Param("ns")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	usage, err := kom.Cluster(selectedCluster).WithContext(ctx).
 		Resource(&v1.Pod{}).
@@ -232,7 +252,11 @@ func Usage(c *gin.Context) {
 }
 
 func UniqueLabels(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	labels := service.PodService().GetUniquePodLabels(selectedCluster)
 

--- a/pkg/controller/pod/pod_file.go
+++ b/pkg/controller/pod/pod_file.go
@@ -32,10 +32,14 @@ type info struct {
 
 // FileList  处理获取文件列表的 HTTP 请求
 func FileList(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	info := &info{}
-	err := c.ShouldBindBodyWithJSON(info)
+	err = c.ShouldBindBodyWithJSON(info)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -64,10 +68,14 @@ func FileList(c *gin.Context) {
 
 // ShowFile 处理下载文件的 HTTP 请求
 func ShowFile(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	info := &info{}
-	err := c.ShouldBindBodyWithJSON(info)
+	err = c.ShouldBindBodyWithJSON(info)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -112,10 +120,14 @@ func ShowFile(c *gin.Context) {
 	})
 }
 func SaveFile(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	info := &info{}
-	err := c.ShouldBindBodyWithJSON(info)
+	err = c.ShouldBindBodyWithJSON(info)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -148,7 +160,11 @@ func SaveFile(c *gin.Context) {
 }
 
 func DownloadFile(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	info := &info{}
 	info.PodName = c.Query("podName")
@@ -164,7 +180,6 @@ func DownloadFile(c *gin.Context) {
 
 	// 从容器中下载文件
 	var fileContent []byte
-	var err error
 	var finalFileName string
 	if c.Query("type") == "tar" {
 		fileContent, err = poder.DownloadTarFile(info.Path)
@@ -189,7 +204,11 @@ func DownloadFile(c *gin.Context) {
 
 // UploadFile 处理上传文件的 HTTP 请求
 func UploadFile(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	info := &info{}
 
@@ -284,10 +303,14 @@ func UploadFile(c *gin.Context) {
 
 }
 func DeleteFile(c *gin.Context) {
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	info := &info{}
-	err := c.ShouldBindBodyWithJSON(info)
+	err = c.ShouldBindBodyWithJSON(info)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return

--- a/pkg/controller/pod/pod_xterm.go
+++ b/pkg/controller/pod/pod_xterm.go
@@ -83,7 +83,11 @@ func cmdLogger(c *gin.Context, cmd string) {
 	ns := c.Param("ns")
 	podName := c.Param("pod_name")
 	containerName := c.Query("container_name")
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	cmd = utils.CleanANSISequences(cmd)
 	username, role := amis.GetLoginUser(c)
 	log := models.ShellLog{
@@ -105,10 +109,13 @@ func Xterm(c *gin.Context) {
 	podName := c.Param("pod_name")
 	containerName := c.Query("container_name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	// TODO 转移到kom中，走cb
-	var err error
 	username := fmt.Sprintf("%s", ctx.Value(constants.JwtUserName))
 	roles := fmt.Sprintf("%s", ctx.Value(constants.JwtUserRole))
 	clusterRoles, _ := service.UserService().GetClusterRole(selectedCluster, username, roles)

--- a/pkg/controller/rs/rs.go
+++ b/pkg/controller/rs/rs.go
@@ -16,16 +16,24 @@ func Restart(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ReplicaSet{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ReplicaSet{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Restart()
 	amis.WriteJsonErrorOrOK(c, err)
 }
 
 func BatchRestart(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -36,7 +44,6 @@ func BatchRestart(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -58,7 +65,11 @@ func BatchRestart(c *gin.Context) {
 
 func BatchStop(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -69,7 +80,6 @@ func BatchStop(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -91,7 +101,11 @@ func BatchStop(c *gin.Context) {
 
 func BatchRestore(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -102,7 +116,6 @@ func BatchRestore(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -127,14 +140,18 @@ func Event(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var metas []string
 
 	metas = append(metas, name)
 	var rs *v1.ReplicaSet
 	// 先取rs
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ReplicaSet{}).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ReplicaSet{}).
 		Namespace(ns).Name(name).Get(&rs).Error
 	if err != nil {
 		amis.WriteJsonError(c, err)
@@ -187,7 +204,11 @@ func HPA(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	hpa, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.ReplicaSet{}).Namespace(ns).Name(name).
 		Ctl().ReplicaSet().HPAList()
 	if err != nil {

--- a/pkg/controller/storageclass/storage_class.go
+++ b/pkg/controller/storageclass/storage_class.go
@@ -12,9 +12,13 @@ import (
 func SetDefault(c *gin.Context) {
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Resource(&v1.StorageClass{}).Name(name).
 		Ctl().StorageClass().SetDefault()
 	if err != nil {
@@ -26,10 +30,14 @@ func SetDefault(c *gin.Context) {
 
 func OptionList(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var list []v1.StorageClass
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.StorageClass{}).List(&list).Error
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.StorageClass{}).List(&list).Error
 	if err != nil {
 		amis.WriteJsonData(c, gin.H{
 			"options": make([]map[string]string, 0),

--- a/pkg/controller/sts/sts.go
+++ b/pkg/controller/sts/sts.go
@@ -13,7 +13,11 @@ func History(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	list, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.StatefulSet{}).Namespace(ns).Name(name).
 		Ctl().Rollout().History()
@@ -27,16 +31,24 @@ func Restart(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.StatefulSet{}).Namespace(ns).Name(name).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.StatefulSet{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Restart()
 	amis.WriteJsonErrorOrOK(c, err)
 }
 
 func BatchRestart(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -47,7 +59,6 @@ func BatchRestart(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -69,7 +80,11 @@ func BatchRestart(c *gin.Context) {
 
 func BatchStop(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -80,7 +95,6 @@ func BatchStop(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -102,7 +116,11 @@ func BatchStop(c *gin.Context) {
 
 func BatchRestore(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Names      []string `json:"name_list"`
@@ -113,7 +131,6 @@ func BatchRestore(c *gin.Context) {
 		return
 	}
 
-	var err error
 	for i := 0; i < len(req.Names); i++ {
 		name := req.Names[i]
 		ns := req.Namespaces[i]
@@ -137,10 +154,14 @@ func Scale(c *gin.Context) {
 	name := c.Param("name")
 	replica := c.Param("replica")
 	r := utils.ToInt32(replica)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	ctx := amis.GetContextWithUser(c)
-	err := kom.Cluster(selectedCluster).WithContext(ctx).
+	err = kom.Cluster(selectedCluster).WithContext(ctx).
 		Resource(&v1.StatefulSet{}).
 		Namespace(ns).Name(name).
 		Ctl().Scaler().Scale(r)
@@ -152,7 +173,11 @@ func Undo(c *gin.Context) {
 	revision := c.Param("revision")
 	ctx := amis.GetContextWithUser(c)
 	r := utils.ToInt(revision)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	result, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.StatefulSet{}).Namespace(ns).Name(name).
 		Ctl().Rollout().Undo(r)
@@ -167,7 +192,11 @@ func HPA(c *gin.Context) {
 	ns := c.Param("ns")
 	name := c.Param("name")
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 	hpa, err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&v1.StatefulSet{}).Namespace(ns).Name(name).
 		Ctl().StatefulSet().HPAList()
 	if err != nil {

--- a/pkg/controller/svc/svc.go
+++ b/pkg/controller/svc/svc.go
@@ -14,7 +14,11 @@ import (
 // Create 创建Service接口
 func Create(c *gin.Context) {
 	ctx := amis.GetContextWithUser(c)
-	selectedCluster := amis.GetSelectedCluster(c)
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
 
 	var req struct {
 		Metadata struct {
@@ -41,7 +45,7 @@ func Create(c *gin.Context) {
 	}
 	// 判断是否存在同名Service
 	var existingService corev1.Service
-	err := kom.Cluster(selectedCluster).WithContext(ctx).Resource(&corev1.Service{}).Name(req.Metadata.Name).Namespace(req.Metadata.Namespace).Get(&existingService).Error
+	err = kom.Cluster(selectedCluster).WithContext(ctx).Resource(&corev1.Service{}).Name(req.Metadata.Name).Namespace(req.Metadata.Namespace).Get(&existingService).Error
 	if err == nil {
 		amis.WriteJsonError(c, fmt.Errorf("Service %s 已存在", req.Metadata.Name))
 		return


### PR DESCRIPTION
在多个控制器中，GetSelectedCluster函数被调用以获取选定的集群。如果集群不存在或获取失败，现在会立即返回错误并中断后续操作，避免潜在的空指针或无效操作。此修改增强了代码的健壮性和错误处理能力。