### PR TITLE
优化指标刷新方式，增加资源超时配置项

### DIFF
--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -19,35 +19,36 @@ var config *Config
 var once sync.Once
 
 type Config struct {
-	Port              int    // gin 监听端口
-	MCPServerPort     int    // MCPServerPort 监听端口
-	KubeConfig        string // KUBECONFIG文件路径
-	ApiKey            string // OPENAI_API_KEY
-	ApiURL            string // OPENAI_API_URL
-	ApiModel          string // OPENAI_MODEL
-	Debug             bool   // 调试模式，同步修改所有的debug模式
-	LogV              int    // klog的日志级别klog.V(this)
-	InCluster         bool   // 是否集群内模式
-	LoginType         string // password,oauth,token,.. 登录方式，默认为password
-	EnableTempAdmin   bool   // 是否启用临时管理员账户配置
-	AdminUserName     string // 管理员用户名，启用临时管理员账户配置后生效
-	AdminPassword     string // 管理员密码，启用临时管理员账户配置后生效
-	JwtTokenSecret    string // JWT token secret
-	NodeShellImage    string // nodeShell 镜像
-	KubectlShellImage string // kubectlShell 镜像
-	ImagePullTimeout  int    // 镜像拉取超时时间（秒）
-	SqlitePath        string // sqlite 数据库路径
-	AnySelect         bool   // 是否开启任意选择，默认开启
-	PrintConfig       bool   // 是否打印配置信息
-	Version           string // 版本号，由编译时自动注入
-	GitCommit         string // git commit, 由编译时自动注入
-	GitTag            string // git tag, 由编译时自动注入
-	GitRepo           string // git仓库地址, 由编译时自动注入
-	BuildDate         string // 编译时间, 由编译时自动注入
-	EnableAI          bool   // 是否启用AI功能，默认开启
-	ConnectCluster    bool   // 启动程序后，是否自动连接发现的集群，默认关闭
-	UseBuiltInModel   bool   // 是否使用内置大模型参数，默认开启
-	ProductName       string // 产品名称，默认为K8M
+	Port                 int    // gin 监听端口
+	MCPServerPort        int    // MCPServerPort 监听端口
+	KubeConfig           string // KUBECONFIG文件路径
+	ApiKey               string // OPENAI_API_KEY
+	ApiURL               string // OPENAI_API_URL
+	ApiModel             string // OPENAI_MODEL
+	Debug                bool   // 调试模式，同步修改所有的debug模式
+	LogV                 int    // klog的日志级别klog.V(this)
+	InCluster            bool   // 是否集群内模式
+	LoginType            string // password,oauth,token,.. 登录方式，默认为password
+	EnableTempAdmin      bool   // 是否启用临时管理员账户配置
+	AdminUserName        string // 管理员用户名，启用临时管理员账户配置后生效
+	AdminPassword        string // 管理员密码，启用临时管理员账户配置后生效
+	JwtTokenSecret       string // JWT token secret
+	NodeShellImage       string // nodeShell 镜像
+	KubectlShellImage    string // kubectlShell 镜像
+	ImagePullTimeout     int    // 镜像拉取超时时间（秒）
+	SqlitePath           string // sqlite 数据库路径
+	AnySelect            bool   // 是否开启任意选择，默认开启
+	PrintConfig          bool   // 是否打印配置信息
+	Version              string // 版本号，由编译时自动注入
+	GitCommit            string // git commit, 由编译时自动注入
+	GitTag               string // git tag, 由编译时自动注入
+	GitRepo              string // git仓库地址, 由编译时自动注入
+	BuildDate            string // 编译时间, 由编译时自动注入
+	EnableAI             bool   // 是否启用AI功能，默认开启
+	ConnectCluster       bool   // 启动程序后，是否自动连接发现的集群，默认关闭
+	UseBuiltInModel      bool   // 是否使用内置大模型参数，默认开启
+	ProductName          string // 产品名称，默认为K8M
+	ResourceCacheTimeout int    // 资源缓存时间（秒）
 }
 
 func Init() *Config {
@@ -150,6 +151,9 @@ func (c *Config) InitFlags() {
 	// 默认产品名称为K8M
 	defaultProductName := getEnv("PRODUCT_NAME", "K8M")
 
+	// 默认资源缓存时间为60秒
+	defaultResourceCacheTimeout := getEnvAsInt("RESOURCE_CACHE_TIMEOUT", 60)
+
 	pflag.BoolVarP(&c.Debug, "debug", "d", defaultDebug, "调试模式")
 	pflag.IntVarP(&c.Port, "port", "p", defaultPort, "监听端口,默认3618")
 	pflag.StringVarP(&c.ApiKey, "chatgpt-key", "k", defaultApiKey, "大模型的自定义API Key")
@@ -174,6 +178,7 @@ func (c *Config) InitFlags() {
 	pflag.BoolVar(&c.UseBuiltInModel, "use-builtin-model", defaultUseBuiltInModel, "是否使用内置大模型参数，默认开启")
 	pflag.IntVar(&c.ImagePullTimeout, "image-pull-timeout", defaultImagePullTimeout, "镜像拉取超时时间（秒），默认30秒")
 	pflag.StringVar(&c.ProductName, "product-name", defaultProductName, "产品名称，默认为K8M")
+	pflag.IntVar(&c.ResourceCacheTimeout, "resource-cache-timeout", defaultResourceCacheTimeout, "资源缓存时间（秒），默认60秒")
 	// 检查是否设置了 --v 参数
 	if vFlag := pflag.Lookup("v"); vFlag == nil || vFlag.Value.String() == "0" {
 		// 如果没有设置，手动将 --v 设置为 环境变量值

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -5,28 +5,21 @@ import (
 )
 
 type Config struct {
-	ID          uint   `gorm:"primaryKey;autoIncrement" json:"id,omitempty"`
-	ProductName string `json:"product_name,omitempty"` // 产品名称
-	// Port              int       `json:"port,omitempty"`
-	// MCPServerPort     int       `json:"mcp_server_port,omitempty"`
-	// KubeConfig        string    `json:"kube_config,omitempty"`
-	ApiKey   string `json:"api_key,omitempty"`
-	ApiURL   string `json:"api_url,omitempty"`
-	ApiModel string `json:"api_model,omitempty"`
-	// Debug             bool      `gorm:"default:false" json:"debug"`
-	// LogV              int       `json:"log_v,omitempty"`
-	// InCluster         bool      `gorm:"default:true" json:"in_cluster"`
-	LoginType         string `json:"login_type,omitempty"`
-	JwtTokenSecret    string `json:"jwt_token_secret,omitempty"`
-	NodeShellImage    string `json:"node_shell_image,omitempty"`
-	KubectlShellImage string `json:"kubectl_shell_image,omitempty"`
-	ImagePullTimeout  int    `gorm:"default:30" json:"image_pull_timeout,omitempty"` // 镜像拉取超时时间（秒）
-	// SqlitePath        string    `json:"sqlite_path,omitempty"`
-	AnySelect       bool `gorm:"default:true" json:"any_select"`
-	PrintConfig     bool `json:"print_config"`
-	EnableAI        bool `gorm:"default:true" json:"enable_ai"` // 是否启用AI功能，默认开启
-	UseBuiltInModel bool `gorm:"default:true" json:"use_built_in_model"`
-	// ConnectCluster  bool      `json:"connect_cluster"`      // 启动集群是是否自动连接现有集群，默认关闭
-	CreatedAt time.Time `json:"created_at,omitempty"` // Automatically managed by GORM for creation time
-	UpdatedAt time.Time `json:"updated_at,omitempty"` // Automatically managed by GORM for update time
+	ID                   uint      `gorm:"primaryKey;autoIncrement" json:"id,omitempty"`
+	ProductName          string    `json:"product_name,omitempty"` // 产品名称
+	ApiKey               string    `json:"api_key,omitempty"`
+	ApiURL               string    `json:"api_url,omitempty"`
+	ApiModel             string    `json:"api_model,omitempty"`
+	LoginType            string    `json:"login_type,omitempty"`
+	JwtTokenSecret       string    `json:"jwt_token_secret,omitempty"`
+	NodeShellImage       string    `json:"node_shell_image,omitempty"`
+	KubectlShellImage    string    `json:"kubectl_shell_image,omitempty"`
+	ImagePullTimeout     int       `gorm:"default:30" json:"image_pull_timeout,omitempty"` // 镜像拉取超时时间（秒）
+	AnySelect            bool      `gorm:"default:true" json:"any_select"`
+	PrintConfig          bool      `json:"print_config"`
+	EnableAI             bool      `gorm:"default:true" json:"enable_ai"` // 是否启用AI功能，默认开启
+	UseBuiltInModel      bool      `gorm:"default:true" json:"use_built_in_model"`
+	ResourceCacheTimeout int       `gorm:"default:60" json:"resource_cache_timeout,omitempty"` // 资源缓存时间（秒）
+	CreatedAt            time.Time `json:"created_at,omitempty"`                               // Automatically managed by GORM for creation time
+	UpdatedAt            time.Time `json:"updated_at,omitempty"`                               // Automatically managed by GORM for update time
 }

--- a/pkg/service/config.go
+++ b/pkg/service/config.go
@@ -54,8 +54,6 @@ func (s *configService) UpdateFlagFromDBConfig() error {
 	}
 
 	cfg.AnySelect = m.AnySelect
-	// cfg.Debug = m.Debug
-	// cfg.InCluster = m.InCluster
 
 	cfg.ApiKey = m.ApiKey
 	cfg.ApiModel = m.ApiModel
@@ -78,22 +76,15 @@ func (s *configService) UpdateFlagFromDBConfig() error {
 		cfg.ProductName = m.ProductName
 	}
 
-	// if m.Port > 0 {
-	// 	cfg.Port = m.Port
-	// }
-	// if m.SqlitePath != "" {
-	// 	cfg.SqlitePath = m.SqlitePath
-	// }
-	// if m.MCPServerPort > 0 {
-	// 	cfg.MCPServerPort = m.MCPServerPort
-	// }
-	// if m.LogV > 0 {
-	// 	cfg.LogV = m.LogV
-	// }
-
 	cfg.PrintConfig = m.PrintConfig
 	cfg.EnableAI = m.EnableAI
-	// cfg.ConnectCluster = m.ConnectCluster
+
+	if m.ResourceCacheTimeout > 0 {
+		cfg.ResourceCacheTimeout = m.ResourceCacheTimeout
+	}
+	if cfg.ResourceCacheTimeout == 0 {
+		cfg.ResourceCacheTimeout = 60
+	}
 
 	// JwtTokenSecret 暂不启用，因为前端也要处理
 	// cfg.JwtTokenSecret = m.JwtTokenSecret

--- a/pkg/service/node_watch.go
+++ b/pkg/service/node_watch.go
@@ -19,7 +19,7 @@ type nodeService struct {
 	lock sync.RWMutex
 }
 
-// 定义结构体，
+// NodeLabels 定义结构体，
 type NodeLabels struct {
 	ClusterName string            // 集群名称
 	NodeName    string            // 节点名称

--- a/pkg/service/pod_label.go
+++ b/pkg/service/pod_label.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"fmt"
+)
+
+// PodLabels 定义结构体，用于存储Pod的标签信息
+type PodLabels struct {
+	ClusterName string            // 集群名称
+	Namespace   string            // 命名空间
+	PodName     string            // Pod名称
+	Labels      map[string]string // 标签
+}
+
+// UpdatePodLabels 更新Pod的标签
+func (p *podService) UpdatePodLabels(selectedCluster string, namespace string, podName string, labels map[string]string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.podLabels == nil {
+		p.podLabels = make(map[string][]*PodLabels)
+	}
+	// 查找是否已存在该Pod的标签
+	var found bool
+	if podList, ok := p.podLabels[selectedCluster]; ok {
+		for _, pod := range podList {
+			if pod.Namespace == namespace && pod.PodName == podName {
+				pod.Labels = labels
+				found = true
+				break
+			}
+		}
+	} else {
+		p.podLabels[selectedCluster] = make([]*PodLabels, 0)
+	}
+	// 如果Pod不存在，则添加新Pod
+	if !found {
+		p.podLabels[selectedCluster] = append(p.podLabels[selectedCluster], &PodLabels{
+			ClusterName: selectedCluster,
+			Namespace:   namespace,
+			PodName:     podName,
+			Labels:      labels,
+		})
+	}
+}
+
+// DeletePodLabels 删除Pod的标签
+func (p *podService) DeletePodLabels(selectedCluster string, namespace string, podName string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if podList, ok := p.podLabels[selectedCluster]; ok {
+		for i, pod := range podList {
+			if pod.Namespace == namespace && pod.PodName == podName {
+				// 从切片中删除该Pod
+				p.podLabels[selectedCluster] = append(podList[:i], podList[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
+// GetPodLabels 获取Pod的标签
+func (p *podService) GetPodLabels(selectedCluster string, namespace string, podName string) map[string]string {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	if podList, ok := p.podLabels[selectedCluster]; ok {
+		for _, pod := range podList {
+			if pod.Namespace == namespace && pod.PodName == podName {
+				return pod.Labels
+			}
+		}
+	}
+	return nil
+}
+
+// GetAllPodLabels 获取所有Pod的标签
+func (p *podService) GetAllPodLabels(selectedCluster string) map[string]map[string]string {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	// 创建一个新的map来返回，避免直接返回内部map
+	result := make(map[string]map[string]string)
+	if podList, ok := p.podLabels[selectedCluster]; ok {
+		for _, pod := range podList {
+			key := fmt.Sprintf("%s/%s", pod.Namespace, pod.PodName)
+			labels := make(map[string]string)
+			for k, v := range pod.Labels {
+				labels[k] = v
+			}
+			result[key] = labels
+		}
+	}
+	return result
+}
+
+// GetUniquePodLabels 获取所有Pod标签的唯一集合
+func (p *podService) GetUniquePodLabels(selectedCluster string) map[string]string {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	// 创建一个新的map来存储唯一的标签
+	uniqueLabels := make(map[string]string)
+	// 遍历所有Pod的标签
+	if podList, ok := p.podLabels[selectedCluster]; ok {
+		for _, pod := range podList {
+			// 将每个Pod的标签添加到唯一标签集合中
+			for k, v := range pod.Labels {
+				// 使用 k=v 作为键和值，以支持相同key但不同value的标签
+				labelKey := fmt.Sprintf("%s=%s", k, v)
+				uniqueLabels[labelKey] = labelKey
+			}
+		}
+	}
+	return uniqueLabels
+}

--- a/pkg/service/pod_watch.go
+++ b/pkg/service/pod_watch.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var ttl = 24 * time.Hour
+var ttl = 2 * time.Minute
 
 // StatusCount 定义结构体，以namespace为key进行统计，累计所有的pod数量，以及cpu、内存用量
 type StatusCount struct {
@@ -288,113 +288,6 @@ func (p *podService) Watch() {
 	}
 	inst.Start()
 	klog.V(6).Infof("新增Pod状态定时更新任务【@every 1m】\n")
-}
-
-// 定义结构体，用于存储Pod的标签信息
-type PodLabels struct {
-	ClusterName string            // 集群名称
-	Namespace   string            // 命名空间
-	PodName     string            // Pod名称
-	Labels      map[string]string // 标签
-}
-
-// UpdatePodLabels 更新Pod的标签
-func (p *podService) UpdatePodLabels(selectedCluster string, namespace string, podName string, labels map[string]string) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	if p.podLabels == nil {
-		p.podLabels = make(map[string][]*PodLabels)
-	}
-	// 查找是否已存在该Pod的标签
-	var found bool
-	if podList, ok := p.podLabels[selectedCluster]; ok {
-		for _, pod := range podList {
-			if pod.Namespace == namespace && pod.PodName == podName {
-				pod.Labels = labels
-				found = true
-				break
-			}
-		}
-	} else {
-		p.podLabels[selectedCluster] = make([]*PodLabels, 0)
-	}
-	// 如果Pod不存在，则添加新Pod
-	if !found {
-		p.podLabels[selectedCluster] = append(p.podLabels[selectedCluster], &PodLabels{
-			ClusterName: selectedCluster,
-			Namespace:   namespace,
-			PodName:     podName,
-			Labels:      labels,
-		})
-	}
-}
-
-// DeletePodLabels 删除Pod的标签
-func (p *podService) DeletePodLabels(selectedCluster string, namespace string, podName string) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	if podList, ok := p.podLabels[selectedCluster]; ok {
-		for i, pod := range podList {
-			if pod.Namespace == namespace && pod.PodName == podName {
-				// 从切片中删除该Pod
-				p.podLabels[selectedCluster] = append(podList[:i], podList[i+1:]...)
-				break
-			}
-		}
-	}
-}
-
-// GetPodLabels 获取Pod的标签
-func (p *podService) GetPodLabels(selectedCluster string, namespace string, podName string) map[string]string {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	if podList, ok := p.podLabels[selectedCluster]; ok {
-		for _, pod := range podList {
-			if pod.Namespace == namespace && pod.PodName == podName {
-				return pod.Labels
-			}
-		}
-	}
-	return nil
-}
-
-// GetAllPodLabels 获取所有Pod的标签
-func (p *podService) GetAllPodLabels(selectedCluster string) map[string]map[string]string {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	// 创建一个新的map来返回，避免直接返回内部map
-	result := make(map[string]map[string]string)
-	if podList, ok := p.podLabels[selectedCluster]; ok {
-		for _, pod := range podList {
-			key := fmt.Sprintf("%s/%s", pod.Namespace, pod.PodName)
-			labels := make(map[string]string)
-			for k, v := range pod.Labels {
-				labels[k] = v
-			}
-			result[key] = labels
-		}
-	}
-	return result
-}
-
-// GetUniquePodLabels 获取所有Pod标签的唯一集合
-func (p *podService) GetUniquePodLabels(selectedCluster string) map[string]string {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	// 创建一个新的map来存储唯一的标签
-	uniqueLabels := make(map[string]string)
-	// 遍历所有Pod的标签
-	if podList, ok := p.podLabels[selectedCluster]; ok {
-		for _, pod := range podList {
-			// 将每个Pod的标签添加到唯一标签集合中
-			for k, v := range pod.Labels {
-				// 使用 k=v 作为键和值，以支持相同key但不同value的标签
-				labelKey := fmt.Sprintf("%s=%s", k, v)
-				uniqueLabels[labelKey] = labelKey
-			}
-		}
-	}
-	return uniqueLabels
 }
 
 func (p *podService) watchSingleCluster(selectedCluster string) watch.Interface {

--- a/ui/public/pages/admin/config/config.json
+++ b/ui/public/pages/admin/config/config.json
@@ -79,6 +79,13 @@
                   "title": "集群配置",
                   "body": [
                     {
+                      "name": "resource_cache_timeout",
+                      "type": "input-number",
+                      "label": "资源缓存时间",
+                      "value": 60,
+                      "desc": "界面展示实时用量、指标、Pod元数据等资源的缓存时间（单位：秒），默认60秒"
+                    },
+                    {
                       "name": "image_pull_timeout",
                       "type": "input-number",
                       "label": "镜像拉取超时时间"

--- a/ui/public/pages/admin/config/config.json
+++ b/ui/public/pages/admin/config/config.json
@@ -81,13 +81,15 @@
                     {
                       "name": "resource_cache_timeout",
                       "type": "input-number",
+                      "suffix": "秒",
                       "label": "资源缓存时间",
                       "value": 60,
-                      "desc": "界面展示实时用量、指标、Pod元数据等资源的缓存时间（单位：秒），默认60秒"
+                      "desc": "界面展示实时用量、指标、Pod元数据等资源的缓存时间（单位：秒），默认60秒。时间越短，界面变化越快，但是会增加k8s系统负担。"
                     },
                     {
                       "name": "image_pull_timeout",
                       "type": "input-number",
+                      "suffix": "秒",
                       "label": "镜像拉取超时时间"
                     },
                     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable "Resource Cache Timeout" setting, allowing users to adjust the cache duration for real-time resource usage, metrics, and Pod metadata display. This can be set via the UI, environment variable, or command-line flag.
- **Improvements**
  - The "image_pull_timeout" field in the cluster configuration UI now clearly displays the unit as seconds.
- **Bug Fixes**
  - Cache durations for resource and Pod status are now dynamically configurable instead of being fixed, improving flexibility and control.
- **Refactor**
  - Internal cleanup and restructuring of configuration and caching logic to support the new timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->