### PR TITLE
refactor(client): 更新客户端类型并升级依赖

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-replace github.com/mark3labs/mcp-go => github.com/weibaohui/mcp-go v0.0.1
+replace github.com/mark3labs/mcp-go => github.com/weibaohui/mcp-go v0.0.5
 
 //replace github.com/weibaohui/kom v0.1.20 => github.com/weibaohui/kom main
 //replace github.com/weibaohui/kom v0.2.5 => github.com/weibaohui/kom main
@@ -161,7 +161,7 @@ require (
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/spf13/cast v1.7.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1188,8 +1188,8 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
-github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
-github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
@@ -1219,8 +1219,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/weibaohui/kom v0.2.22 h1:i663Ce+/Nm8/mj4YQZWmjRQ3y29x5E9y9BTEPjIoTRw=
 github.com/weibaohui/kom v0.2.22/go.mod h1:qBU9X5CoRol8g0p7uc7UNitKrZTPCJVfVs2i8+NGOh0=
-github.com/weibaohui/mcp-go v0.0.1 h1:SJAGhcfOcz+V2yB6xLoyUa1KGKqCjcxu29gIzi/mUuI=
-github.com/weibaohui/mcp-go v0.0.1/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
+github.com/weibaohui/mcp-go v0.0.5 h1:uiHCF0vVtO99Cu3NIMOwE2+Rq5fCjAp4vUZmsC8oURY=
+github.com/weibaohui/mcp-go v0.0.5/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/mcp/mcp_call.go
+++ b/pkg/mcp/mcp_call.go
@@ -72,7 +72,7 @@ func (m *MCPHost) ExecTools(ctx context.Context, toolCalls []openai.ToolCall) []
 
 			result.Parameters = args
 
-			var cli *client.SSEMCPClient
+			var cli *client.Client
 			var toolName, serverName string
 			var err error
 			if strings.Contains(fullToolName, "@") {

--- a/pkg/mcp/mcp_host.go
+++ b/pkg/mcp/mcp_host.go
@@ -146,7 +146,7 @@ func (m *MCPHost) ConnectServer(ctx context.Context, serverName string) error {
 }
 
 // GetClient 获取指定服务器的客户端
-func (m *MCPHost) GetClient(ctx context.Context, serverName string) (*client.SSEMCPClient, error) {
+func (m *MCPHost) GetClient(ctx context.Context, serverName string) (*client.Client, error) {
 
 	// 获取配置信息
 	config, exists := m.configs[serverName]


### PR DESCRIPTION
将 `client.SSEMCPClient` 类型统一更新为 `client.Client`，同时将 `github.com/spf13/cast` 依赖从 v1.7.0 升级到 v1.7.1，并将 `github.com/weibaohui/mcp-go` 依赖从 v0.0.1 升级到 v0.0.5