### PR TITLE
feat(ui): 在副本集页面添加副本数搜索功能

### DIFF
--- a/ui/public/pages/ns/replicaset.json
+++ b/ui/public/pages/ns/replicaset.json
@@ -4202,7 +4202,13 @@
           "name": "ready",
           "label": "就绪",
           "type": "tpl",
-          "tpl": "${status.readyReplicas||'0'}/${status.replicas}"
+          "tpl": "${status.readyReplicas||'0'}/${status.replicas}",
+          "searchable": {
+            "type": "input-text",
+            "name": "spec.replicas",
+            "label": "设定副本数",
+            "placeholder": "设定副本数"
+          }
         },
         {
           "name": "metadata.ownerReferences",


### PR DESCRIPTION
在副本集页面的就绪状态字段中，新增了一个可搜索的副本数输入框，方便用户根据设定的副本数进行筛选