### PR TITLE
feat(网关API): 添加网关API支持状态检查及动态菜单显示

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,6 +254,7 @@ func main() {
 		api.POST("/:kind/group/:group/version/:version/update_annotations/ns/:ns/name/:name", dynamic.UpdateAnnotations) // CRD
 		api.GET("/crd/group/option_list", dynamic.GroupOptionList)
 		api.GET("/crd/kind/option_list", dynamic.KindOptionList)
+		api.GET("/crd/status", dynamic.CRDStatus)
 		// Container 信息
 		api.GET("/:kind/group/:group/version/:version/container_info/ns/:ns/name/:name/container/:container_name", dynamic.ContainerInfo)
 		api.GET("/:kind/group/:group/version/:version/container_resources_info/ns/:ns/name/:name/container/:container_name", dynamic.ContainerResourcesInfo)

--- a/pkg/controller/dynamic/crd_status.go
+++ b/pkg/controller/dynamic/crd_status.go
@@ -1,0 +1,18 @@
+package dynamic
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/weibaohui/k8m/pkg/comm/utils/amis"
+	"github.com/weibaohui/kom/kom"
+)
+
+func CRDStatus(c *gin.Context) {
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
+	amis.WriteJsonData(c, gin.H{
+		"IsGatewayAPISupported": kom.Cluster(selectedCluster).Status().IsGatewayAPISupported(),
+	})
+}

--- a/ui/src/components/Sidebar/menu.tsx
+++ b/ui/src/components/Sidebar/menu.tsx
@@ -1,7 +1,7 @@
-import { useNavigate } from "react-router-dom";
-import type { MenuProps } from 'antd';
-import { useEffect, useState } from 'react';
-import { fetcher } from '../Amis/fetcher';
+import {useNavigate} from "react-router-dom";
+import type {MenuProps} from 'antd';
+import {useEffect, useState} from 'react';
+import {fetcher} from '../Amis/fetcher';
 
 // 定义用户角色接口
 interface UserRoleResponse {
@@ -9,11 +9,16 @@ interface UserRoleResponse {
     cluster: string;
 }
 
+interface GatewayAPIStatus {
+    IsGatewayAPISupported: boolean;
+}
+
 type MenuItem = Required<MenuProps>['items'][number];
 
 const items: () => MenuItem[] = () => {
     const navigate = useNavigate()
     const [userRole, setUserRole] = useState<string>('');
+    const [isGatewayAPISupported, setIsGatewayAPISupported] = useState<boolean>(false);
 
     useEffect(() => {
         const fetchUserRole = async () => {
@@ -31,13 +36,29 @@ const items: () => MenuItem[] = () => {
                     if (originCluster == "" && role.cluster != "") {
                         localStorage.setItem('cluster', role.cluster);
                     }
-                    // console.log('User Role:', role.role);
                 }
             } catch (error) {
                 console.error('Failed to fetch user role:', error);
             }
         };
+
+        const fetchGatewayAPIStatus = async () => {
+            try {
+                const response = await fetcher({
+                    url: '/k8s/crd/status',
+                    method: 'get'
+                });
+                if (response.data && typeof response.data === 'object') {
+                    const status = response.data.data as GatewayAPIStatus;
+                    setIsGatewayAPISupported(status.IsGatewayAPISupported);
+                }
+            } catch (error) {
+                console.error('Failed to fetch Gateway API status:', error);
+            }
+        };
+
         fetchUserRole();
+        fetchGatewayAPIStatus();
     }, []);
 
     const onMenuClick = (path: string) => {
@@ -228,53 +249,57 @@ const items: () => MenuItem[] = () => {
                 },
             ],
         },
-        {
-            label: "网关API",
-            icon: <i className="fa-solid fa-door-closed"></i>,
-            key: "GatewayAPI",
-            children: [
-                {
-                    label: "网关类",
-                    icon: <i className="fa-solid fa-door-open"></i>,
-                    key: "gatewayapi_gateway_class",
-                    onClick: () => onMenuClick('/gatewayapi/gateway_class')
-                },
-                {
-                    label: "网关",
-                    icon: <i className="fa-solid fa-archway"></i>,
-                    key: "gatewayapi_gateway",
-                    onClick: () => onMenuClick('/gatewayapi/gateway')
-                },
-                {
-                    label: "HTTP路由",
-                    icon: <i className="fa-solid fa-route"></i>,
-                    key: "gatewayapi_http_route",
-                    onClick: () => onMenuClick('/gatewayapi/http_route')
-                },
-                {
-                    label: "GRPC路由",
-                    icon: <i className="fa-solid fa-code-branch"></i>,
-                    key: "gatewayapi_grpc_route",
-                    onClick: () => onMenuClick('/gatewayapi/grpc_route')
-                },
-                {
-                    label: "TCP路由",
-                    icon: <i className="fa-solid fa-plug"></i>,
-                    key: "gatewayapi_tcp_route",
-                    onClick: () => onMenuClick('/gatewayapi/tcp_route')
-                }, {
-                    label: "UDP路由",
-                    icon: <i className="fa-solid fa-broadcast-tower"></i>,
-                    key: "gatewayapi_udp_route",
-                    onClick: () => onMenuClick('/gatewayapi/udp_route')
-                }, {
-                    label: "TLS路由",
-                    icon: <i className="fa-solid fa-shield-alt"></i>,
-                    key: "gatewayapi_tls_route",
-                    onClick: () => onMenuClick('/gatewayapi/tls_route')
-                },
-            ],
-        },
+        ...(isGatewayAPISupported ? [
+            {
+                label: "网关API",
+                icon: <i className="fa-solid fa-door-closed"></i>,
+                key: "GatewayAPI",
+                children: [
+                    {
+                        label: "网关类",
+                        icon: <i className="fa-solid fa-door-open"></i>,
+                        key: "gatewayapi_gateway_class",
+                        onClick: () => onMenuClick('/gatewayapi/gateway_class')
+                    },
+                    {
+                        label: "网关",
+                        icon: <i className="fa-solid fa-archway"></i>,
+                        key: "gatewayapi_gateway",
+                        onClick: () => onMenuClick('/gatewayapi/gateway')
+                    },
+                    {
+                        label: "HTTP路由",
+                        icon: <i className="fa-solid fa-route"></i>,
+                        key: "gatewayapi_http_route",
+                        onClick: () => onMenuClick('/gatewayapi/http_route')
+                    },
+                    {
+                        label: "GRPC路由",
+                        icon: <i className="fa-solid fa-code-branch"></i>,
+                        key: "gatewayapi_grpc_route",
+                        onClick: () => onMenuClick('/gatewayapi/grpc_route')
+                    },
+                    {
+                        label: "TCP路由",
+                        icon: <i className="fa-solid fa-plug"></i>,
+                        key: "gatewayapi_tcp_route",
+                        onClick: () => onMenuClick('/gatewayapi/tcp_route')
+                    },
+                    {
+                        label: "UDP路由",
+                        icon: <i className="fa-solid fa-broadcast-tower"></i>,
+                        key: "gatewayapi_udp_route",
+                        onClick: () => onMenuClick('/gatewayapi/udp_route')
+                    },
+                    {
+                        label: "TLS路由",
+                        icon: <i className="fa-solid fa-shield-alt"></i>,
+                        key: "gatewayapi_tls_route",
+                        onClick: () => onMenuClick('/gatewayapi/tls_route')
+                    },
+                ],
+            },
+        ] : []),
         {
             label: "存储",
             icon: <i className="fa-solid fa-memory"></i>,


### PR DESCRIPTION
在`crd_status.go`中添加了`CRDStatus`函数，用于检查集群是否支持网关API。在`main.go`中注册了新的API路由`/crd/status`。在`menu.tsx`中增加了对网关API支持状态的获取，并根据状态动态显示或隐藏网关API相关菜单项