### PR TITLE
fix(mcp_host): 处理生成JWT令牌时的错误

### DIFF
--- a/pkg/service/mcp_host.go
+++ b/pkg/service/mcp_host.go
@@ -160,6 +160,9 @@ func (m *MCPHost) GetClient(ctx context.Context, serverName string) (*client.Cli
 
 	username, _ := m.getUserRoleFromMCPCtx(ctx)
 	jwt, err := UserService().GenerateJWTTokenOnlyUserName(username, time.Hour*1)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate JWT token for %s: %v", serverName, err)
+	}
 	// 执行时携带用户名、角色信息
 	newCli, err := client.NewSSEMCPClient(config.URL, client.WithHeaders(map[string]string{
 		"Authorization": jwt,


### PR DESCRIPTION
在生成JWT令牌时，增加了错误处理逻辑，避免因令牌生成失败导致程序崩溃。如果生成失败，返回包含服务器名称和错误信息的错误消息。