### PR TITLE
feat(admin): 新增集群命名空间列表接口并优化命名空间选择功能

### DIFF
--- a/main.go
+++ b/main.go
@@ -526,8 +526,9 @@ func main() {
 
 		// 集群权限设置
 		admin.GET("/cluster_permissions/cluster/:cluster/role/:role/user/list", user.ListClusterPermissions)
-		admin.GET("/cluster_permissions/user/:username/list", user.ListClusterPermissionsByUserName)    // 列出指定用户拥有的集群权限
-		admin.GET("/cluster_permissions/cluster/:cluster/list", user.ListClusterPermissionsByClusterID) // 列出指定集群下所有授权情况
+		admin.GET("/cluster_permissions/user/:username/list", user.ListClusterPermissionsByUserName)         // 列出指定用户拥有的集群权限
+		admin.GET("/cluster_permissions/cluster/:cluster/list", user.ListClusterPermissionsByClusterID)      // 列出指定集群下所有授权情况
+		admin.GET("/cluster_permissions/cluster/:cluster/ns/list", user.ListClusterNamespaceListByClusterID) // 列出指定集群下所有授权情况
 		admin.POST("/cluster_permissions/cluster/:cluster/role/:role/:role_type/save", user.SaveClusterPermission)
 		admin.POST("/cluster_permissions/:ids", user.DeleteClusterPermission)
 		admin.POST("/cluster_permissions/update_namespaces/:id", user.UpdateNamespaces)

--- a/ui/public/pages/admin/cluster/cluster_all.json
+++ b/ui/public/pages/admin/cluster/cluster_all.json
@@ -91,7 +91,7 @@
                 "closeOnEsc": true,
                 "closeOnOutside": true,
                 "title": "集群权限管理",
-                "size": "lg",
+                "size": "xl",
                 "body": [
                   {
                     "type": "alert",
@@ -107,7 +107,6 @@
                           {
                             "type": "crud",
                             "api": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/role/cluster_readonly/user/list",
-                            "quickSaveItemApi": "/admin/cluster_permissions/update_namespaces/$id",
                             "autoFillHeight": true,
                             "autoGenerateFilter": {
                               "columnsNum": 4,
@@ -223,15 +222,30 @@
                                 "label": "限制命名空间",
                                 "type": "tpl",
                                 "tpl": "${namespaces | split:',')}",
-                                "placeholder": "-",
-                                "quickEdit": {
-                                  "type": "input-array",
-                                  "inline": true,
-                                  "items": {
-                                    "type": "input-text",
-                                    "clearable": false
-                                  },
-                                  "saveImmediately": true
+                                "placeholder": "-"
+                              },
+                              {
+                                "type": "button",
+                                "label": "选择命名空间",
+                                "actionType": "dialog",
+                                "dialog": {
+                                  "closeOnEsc": true,
+                                  "closeOnOutside": true,
+                                  "size": "lg",
+                                  "title": "选择限制命名空间",
+                                  "body": {
+                                    "type": "form",
+                                    "api": "post:/admin/cluster_permissions/update_namespaces/$id",
+                                    "body": [
+                                      {
+                                        "type": "transfer",
+                                        "name": "namespaces",
+                                        "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
+                                        "searchable": true,
+                                        "selectMode": "list"
+                                      }
+                                    ]
+                                  }
                                 }
                               },
                               {
@@ -254,7 +268,6 @@
                           {
                             "type": "crud",
                             "api": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/role/cluster_pod_exec/user/list",
-                            "quickSaveItemApi": "/admin/cluster_permissions/update_namespaces/$id",
                             "autoFillHeight": true,
                             "autoGenerateFilter": {
                               "columnsNum": 4,
@@ -370,15 +383,30 @@
                                 "label": "限制命名空间",
                                 "type": "tpl",
                                 "tpl": "${namespaces | split:',')}",
-                                "placeholder": "-",
-                                "quickEdit": {
-                                  "type": "input-array",
-                                  "inline": true,
-                                  "items": {
-                                    "type": "input-text",
-                                    "clearable": false
-                                  },
-                                  "saveImmediately": true
+                                "placeholder": "-"
+                              },
+                              {
+                                "type": "button",
+                                "label": "选择命名空间",
+                                "actionType": "dialog",
+                                "dialog": {
+                                  "closeOnEsc": true,
+                                  "closeOnOutside": true,
+                                  "size": "lg",
+                                  "title": "选择限制命名空间",
+                                  "body": {
+                                    "type": "form",
+                                    "api": "post:/admin/cluster_permissions/update_namespaces/$id",
+                                    "body": [
+                                      {
+                                        "type": "transfer",
+                                        "name": "namespaces",
+                                        "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
+                                        "searchable": true,
+                                        "selectMode": "list"
+                                      }
+                                    ]
+                                  }
                                 }
                               },
                               {
@@ -401,7 +429,6 @@
                           {
                             "type": "crud",
                             "api": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/role/cluster_admin/user/list",
-                            "quickSaveItemApi": "/admin/cluster_permissions/update_namespaces/$id",
                             "autoFillHeight": true,
                             "autoGenerateFilter": {
                               "columnsNum": 4,
@@ -517,15 +544,30 @@
                                 "label": "限制命名空间",
                                 "type": "tpl",
                                 "tpl": "${namespaces | split:',')}",
-                                "placeholder": "-",
-                                "quickEdit": {
-                                  "type": "input-array",
-                                  "inline": true,
-                                  "items": {
-                                    "type": "input-text",
-                                    "clearable": false
-                                  },
-                                  "saveImmediately": true
+                                "placeholder": "-"
+                              },
+                              {
+                                "type": "button",
+                                "label": "选择命名空间",
+                                "actionType": "dialog",
+                                "dialog": {
+                                  "closeOnEsc": true,
+                                  "closeOnOutside": true,
+                                  "size": "lg",
+                                  "title": "选择限制命名空间",
+                                  "body": {
+                                    "type": "form",
+                                    "api": "post:/admin/cluster_permissions/update_namespaces/$id",
+                                    "body": [
+                                      {
+                                        "type": "transfer",
+                                        "name": "namespaces",
+                                        "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
+                                        "searchable": true,
+                                        "selectMode": "list"
+                                      }
+                                    ]
+                                  }
                                 }
                               },
                               {


### PR DESCRIPTION
新增`ListClusterNamespaceListByClusterID`接口，用于获取集群下的命名空间列表。优化了命名空间选择功能，将原有的`input-array`替换为`transfer`组件，提升用户体验。