### PR TITLE
perf(dao): 设置SQLite最大打开连接数为1

### DIFF
--- a/internal/dao/conn.go
+++ b/internal/dao/conn.go
@@ -63,7 +63,12 @@ func connDB() (*gorm.DB, error) {
 			return
 		}
 		klog.V(4).Infof("已连接数据库[%s].", cfg.SqlitePath)
-
+		s, err := db.DB()
+		if err != nil {
+			dbErr = err
+			return
+		}
+		s.SetMaxOpenConns(1)
 		dbInstance = db
 	})
 


### PR DESCRIPTION
为了避免SQLite数据库的并发问题，设置最大打开连接数为1，确保每次只有一个连接访问数据库，从而提高稳定性和性能。