### PR TITLE
refactor: 清空对话历史后忽略返回数据

### DIFF
--- a/ui/src/components/Amis/custom/WebSocketChatGPT.tsx
+++ b/ui/src/components/Amis/custom/WebSocketChatGPT.tsx
@@ -267,7 +267,7 @@ const WebSocketChatGPT = React.forwardRef<HTMLDivElement, WebSocketChatGPTProps>
                                         onClick={() => {
                                             fetch(historyResetUrl)
                                                 .then(response => response.json())
-                                                .then(data => {
+                                                .then(_ => {
                                                     Modal.success({
                                                         content: '对话历史已清空。',
                                                     });


### PR DESCRIPTION
在清空对话历史的回调函数中，忽略返回的数据，仅显示成功提示