### PR TITLE
refactor(middleware): 移除静态文件后缀列表中的 ".json"

### DIFF
--- a/pkg/middleware/cache.go
+++ b/pkg/middleware/cache.go
@@ -24,7 +24,7 @@ func SetCacheHeaders() gin.HandlerFunc {
 		}
 		if ext != "" {
 			// 常见的静态文件后缀
-			staticExts := []string{".json", ".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".woff", ".woff2", ".ttf", ".eot", ".map"}
+			staticExts := []string{".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".woff", ".woff2", ".ttf", ".eot", ".map"}
 			if !slices.Contains(staticExts, ext) {
 				// 静态文件请求，直接跳过集群检测
 				c.Next()


### PR DESCRIPTION
移除 ".json" 后缀，因为 JSON 文件通常不需要缓存头设置，避免不必要的处理