### PR TITLE
refactor(ui): 移除集群管理页面中的命名空间选择功能

### DIFF
--- a/ui/public/pages/admin/cluster/cluster_all.json
+++ b/ui/public/pages/admin/cluster/cluster_all.json
@@ -540,37 +540,6 @@
                                 "label": "集群"
                               },
                               {
-                                "name": "namespaces",
-                                "label": "限制命名空间",
-                                "type": "tpl",
-                                "tpl": "${namespaces | split:',')}",
-                                "placeholder": "-"
-                              },
-                              {
-                                "type": "button",
-                                "label": "选择命名空间",
-                                "actionType": "dialog",
-                                "dialog": {
-                                  "closeOnEsc": true,
-                                  "closeOnOutside": true,
-                                  "size": "lg",
-                                  "title": "选择限制命名空间",
-                                  "body": {
-                                    "type": "form",
-                                    "api": "post:/admin/cluster_permissions/update_namespaces/$id",
-                                    "body": [
-                                      {
-                                        "type": "transfer",
-                                        "name": "namespaces",
-                                        "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
-                                        "searchable": true,
-                                        "selectMode": "list"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
                                 "name": "authorization_type",
                                 "label": "授权类型",
                                 "type": "mapping",

--- a/ui/public/pages/ns/daemonset.json
+++ b/ui/public/pages/ns/daemonset.json
@@ -1299,7 +1299,11 @@
                                     "type": "input-kv",
                                     "name": "envs",
                                     "draggable": false,
-                                    "value": "${envs}"
+                                    "value": "${envs}",
+                                    "valueSchema": {
+                                      "type": "textarea",
+                                      "minRows": 1
+                                    }
                                   }
                                 ]
                               }

--- a/ui/public/pages/ns/deploy.json
+++ b/ui/public/pages/ns/deploy.json
@@ -1470,7 +1470,11 @@
                                     "type": "input-kv",
                                     "name": "envs",
                                     "draggable": false,
-                                    "value": "${envs}"
+                                    "value": "${envs}",
+                                    "valueSchema": {
+                                      "type": "textarea",
+                                      "minRows": 1
+                                    }
                                   }
                                 ]
                               }

--- a/ui/public/pages/ns/replicaset.json
+++ b/ui/public/pages/ns/replicaset.json
@@ -1178,7 +1178,11 @@
                                     "type": "input-kv",
                                     "name": "envs",
                                     "draggable": false,
-                                    "value": "${envs}"
+                                    "value": "${envs}",
+                                    "valueSchema": {
+                                      "type": "textarea",
+                                      "minRows": 1
+                                    }
                                   }
                                 ]
                               }

--- a/ui/public/pages/ns/statefulset.json
+++ b/ui/public/pages/ns/statefulset.json
@@ -1344,7 +1344,11 @@
                                     "type": "input-kv",
                                     "name": "envs",
                                     "draggable": false,
-                                    "value": "${envs}"
+                                    "value": "${envs}",
+                                    "valueSchema": {
+                                      "type": "textarea",
+                                      "minRows": 1
+                                    }
                                   }
                                 ]
                               }

--- a/ui/public/pages/user/profile/mcp_keys.json
+++ b/ui/public/pages/user/profile/mcp_keys.json
@@ -16,7 +16,9 @@
       "className": "text-info",
       "actionType": "dialog",
       "dialog": {
-        "title": "MCP服务使用说明",
+        "title": "MCP服务使用说明（ESC 关闭）",
+        "closeOnEsc": true,
+        "closeOnOutside": true,
         "size": "lg",
         "body": "<div><p><strong>1. 适用工具和软件</strong></p><ul style='margin-left:20px'><li>CherryStudio - AI开发助手</li><li>Cline - 命令行工具</li><li>Cursor - AI编程工具</li><li>其他支持自定义MCP接入的软件</li></ul><p><strong>2. 访问地址</strong></p><ul style='margin-left:20px'><li>统一访问地址：<code><%= window.location.protocol + '//' + window.location.hostname + ':3618' %>/mcp/k8m/sse</code></li><li>如使用NodePort方式访问，请将域名替换为集群节点IP，端口替换为NodePort端口</li><li>如使用网关方式访问，请将域名和端口替换为网关地址</li><li>如您不能确定访问方式，可联系系统管理员</li></ul><p><strong>3. 认证方式说明</strong></p><ul style='margin-left:20px'><li>使用Bearer Token认证</li><li>在HTTP请求头中添加：<code>Authorization: Bearer {AUTH_TOKEN}</code></li><li>AUTH_TOKEN即为表格中显示的认证Token</li><li>每个Token具有独立的访问权限，跟您的访问权限进行了绑定，请勿分享给他人</li><li>建议定期更换Token以确保安全性</li></ul></div>"
       }


### PR DESCRIPTION
为了简化集群管理页面的用户界面，移除了命名空间选择功能及其相关代码。此功能在当前使用场景中不再需要，减少了不必要的复杂性。