### PR TITLE
fix(service): 修复获取用户集群角色时未包含用户组角色问题

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sashabaranov/go-openai v1.39.1
 	github.com/spf13/pflag v1.0.6
-	github.com/weibaohui/kom v0.2.41
+	github.com/weibaohui/kom v0.2.43
 	golang.org/x/net v0.40.0
 	golang.org/x/oauth2 v0.30.0
 	gorm.io/driver/mysql v1.5.7

--- a/go.sum
+++ b/go.sum
@@ -1235,8 +1235,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/weibaohui/kom v0.2.41 h1:Nwc9T015Gau62K0xyuSA3qBDrhGADnrZvCcrZtHETGM=
-github.com/weibaohui/kom v0.2.41/go.mod h1:hHwoeied9BMa6NmDYo+5GpubuRpztrPlIQgBh36A6fU=
+github.com/weibaohui/kom v0.2.43 h1:GMNTMyPplt8QhHsz1SfNgwartaq9K9XrtRtp+pTqQj8=
+github.com/weibaohui/kom v0.2.43/go.mod h1:hHwoeied9BMa6NmDYo+5GpubuRpztrPlIQgBh36A6fU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=


### PR DESCRIPTION
修改GetClusterRole方法，在查询用户集群角色时同时包含用户本身及其所属用户组的角色。原实现仅查询用户本身的角色，导致用户组权限无法生效。

主要变更：
- 将用户组名称加入查询条件
- 更新相关注释说明