### PR TITLE
fix(XTerm): 修复工作负载/部署 容器组控制台功能在Linux系统浏览器上打开报错的问题

### DIFF
--- a/ui/src/components/Amis/custom/XTerm.tsx
+++ b/ui/src/components/Amis/custom/XTerm.tsx
@@ -50,7 +50,7 @@ const XTermComponent = React.forwardRef<HTMLDivElement, XTermProps>(
                 return;
             }
 
-            const ws = new WebSocket(url);
+            const ws = new WebSocket(`ws://${location.host}` + url);
             wsRef.current = ws;
             // 添加插件
             const attachAddon = new AttachAddon(ws);


### PR DESCRIPTION
修改文件ui/src/components/Amis/custom/XTerm.tsx 53行

const ws = new WebSocket(`ws://${location.host}` + url);

在早期的浏览器实现中，WebSocket 的支持并不完善。低版本的 Chrome 可能没有完全实现对相对路径的支持，或者出于兼容性考虑，只支持绝对路径。随着浏览器版本的更新，WebSocket 的实现逐渐完善，但规范仍然要求使用绝对路径，以保持一致性和安全性。