### PR TITLE
新增黑白名单命名空间限制。

### DIFF
--- a/main.go
+++ b/main.go
@@ -557,6 +557,7 @@ func main() {
 		admin.POST("/cluster_permissions/cluster/:cluster/role/:role/:authorization_type/save", user.SaveClusterPermission)
 		admin.POST("/cluster_permissions/:ids", user.DeleteClusterPermission)
 		admin.POST("/cluster_permissions/update_namespaces/:id", user.UpdateNamespaces)
+		admin.POST("/cluster_permissions/update_blacklist_namespaces/:id", user.UpdateBlacklistNamespaces)
 
 		// 管理集群、纳管\解除纳管\扫描
 		admin.POST("/cluster/scan", cluster.Scan)

--- a/pkg/cb/cb.go
+++ b/pkg/cb/cb.go
@@ -141,6 +141,14 @@ func handleCommonLogic(k8s *kom.Kubectl, action string) (string, []string, error
 			if len(nsList) > 0 {
 				// 具备只读+Exec权限了，那么继续看是否有该ns的权限.
 				// ns为空，或者ns列表中含有当前ns，那么就允许执行。
+
+				//首先看是否在ns黑名单中，在的话阻止
+				execClustersWithBNs := slice.Filter(execClusters, func(index int, item *models.ClusterUserRole) bool {
+					return item.BlacklistNamespaces != "" && utils.AnyIn(nsList, strings.Split(item.BlacklistNamespaces, ","))
+				})
+				if len(execClustersWithBNs) > 0 {
+					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限-命名空间黑名单", username, cluster, strings.Join(nsList, ","))
+				}
 				execClustersWithNs := slice.Filter(execClusters, func(index int, item *models.ClusterUserRole) bool {
 					return item.Namespaces == "" || utils.AllIn(nsList, strings.Split(item.Namespaces, ","))
 				})
@@ -151,6 +159,15 @@ func handleCommonLogic(k8s *kom.Kubectl, action string) (string, []string, error
 		} else {
 			//  有集群权限，那么继续看是否有该ns的权限.
 			if len(nsList) > 0 {
+
+				//首先看是否在ns黑名单中，在的话阻止
+				execClustersWithBNs := slice.Filter(manageClusters, func(index int, item *models.ClusterUserRole) bool {
+					return item.BlacklistNamespaces != "" && utils.AnyIn(nsList, strings.Split(item.BlacklistNamespaces, ","))
+				})
+				if len(execClustersWithBNs) > 0 {
+					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限-命名空间黑名单", username, cluster, strings.Join(nsList, ","))
+				}
+
 				// ns为空，或者ns列表中含有当前ns，那么就允许执行。
 				execClustersWithNs := slice.Filter(manageClusters, func(index int, item *models.ClusterUserRole) bool {
 					return item.Namespaces == "" || utils.AllIn(nsList, strings.Split(item.Namespaces, ","))
@@ -171,6 +188,15 @@ func handleCommonLogic(k8s *kom.Kubectl, action string) (string, []string, error
 		if len(nsList) > 0 {
 			// 具备操作权限了，那么继续看是否有该ns的权限.
 			// ns为空，或者ns列表中含有当前ns，那么就允许执行。
+
+			//首先看是否在ns黑名单中，在的话阻止
+			execClustersWithBNs := slice.Filter(changeClusters, func(index int, item *models.ClusterUserRole) bool {
+				return item.BlacklistNamespaces != "" && utils.AnyIn(nsList, strings.Split(item.BlacklistNamespaces, ","))
+			})
+			if len(execClustersWithBNs) > 0 {
+				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 操作权限-命名空间黑名单", username, cluster, strings.Join(nsList, ","))
+			}
+
 			changeClustersWithNs := slice.Filter(changeClusters, func(index int, item *models.ClusterUserRole) bool {
 				return item.Namespaces == "" || utils.AllIn(nsList, strings.Split(item.Namespaces, ","))
 			})
@@ -191,6 +217,15 @@ func handleCommonLogic(k8s *kom.Kubectl, action string) (string, []string, error
 		if len(nsList) > 0 {
 			// 具备操作权限了，那么继续看是否有该ns的权限.
 			// ns为空，或者ns列表中含有当前ns，那么就允许执行。
+
+			//首先看是否在ns黑名单中，在的话阻止
+			execClustersWithBNs := slice.Filter(readClusters, func(index int, item *models.ClusterUserRole) bool {
+				return item.BlacklistNamespaces != "" && utils.AnyIn(nsList, strings.Split(item.BlacklistNamespaces, ","))
+			})
+			if len(execClustersWithBNs) > 0 {
+				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 读取权限-命名空间黑名单", username, cluster, strings.Join(nsList, ","))
+			}
+
 			readClustersWithNs := slice.Filter(readClusters, func(index int, item *models.ClusterUserRole) bool {
 				return item.Namespaces == "" || utils.AllIn(nsList, strings.Split(item.Namespaces, ","))
 			})

--- a/pkg/comm/utils/amis/gin.go
+++ b/pkg/comm/utils/amis/gin.go
@@ -44,6 +44,7 @@ func GetLoginUser(c *gin.Context) (string, string) {
 
 // GetLoginUserWithClusterRoles 获取当前登录用户名及其角色,已经授权的集群角色
 // 返回值: 用户名, 角色, 集群角色列表
+// Deprecated: 请使用UserService
 func GetLoginUserWithClusterRoles(c *gin.Context) (string, string, []*models.ClusterUserRole) {
 	user := c.GetString(constants.JwtUserName)
 	role := c.GetString(constants.JwtUserRole)

--- a/pkg/comm/utils/slice.go
+++ b/pkg/comm/utils/slice.go
@@ -32,3 +32,25 @@ func AllIn(a, b []string) bool {
 	}
 	return true
 }
+
+// AnyIn 判断A数组中的元素，是否有任意一个存在于B数组中
+// a := []string{"apple", "kiwi"}
+// b := []string{"apple", "banana", "cherry"}
+//
+// fmt.Println(AnyIn(a, b)) // true，因为"apple"在b中
+//
+// a2 := []string{"grape", "kiwi"}
+// fmt.Println(AnyIn(a2, b)) // false，因为没有元素在b中
+func AnyIn(a, b []string) bool {
+	bSet := make(map[string]struct{}, len(b))
+	for _, item := range b {
+		bSet[item] = struct{}{}
+	}
+
+	for _, item := range a {
+		if _, ok := bSet[item]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/ns/ns.go
+++ b/pkg/controller/ns/ns.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weibaohui/k8m/pkg/service"
 	"github.com/weibaohui/kom/kom"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
 
 func OptionList(c *gin.Context) {
@@ -65,7 +66,11 @@ func handlePlatformAdmin(c *gin.Context, selectedCluster string) ([]map[string]s
 }
 
 func handleNormalUser(c *gin.Context, selectedCluster string) ([]map[string]string, bool) {
-	_, _, clusterUserRoles := amis.GetLoginUserWithClusterRoles(c)
+	user, _ := amis.GetLoginUser(c)
+	clusterUserRoles, err := service.UserService().GetClusters(user)
+	if err != nil {
+		return make([]map[string]string, 0), true
+	}
 	if clusterUserRoles == nil {
 		return nil, false
 	}
@@ -109,7 +114,65 @@ func handleUserWithoutNamespaceRestriction(ctx context.Context, selectedCluster 
 	return nsList, true
 }
 
+func handleBlacklist(c *gin.Context, selectedCluster string, list []map[string]string) ([]map[string]string, bool) {
+	user, _ := amis.GetLoginUser(c)
+	clusterUserRoles, err := service.UserService().GetClusters(user)
+	if err != nil {
+		return list, true
+	}
+	// 筛选带有黑名单 ns的授权列表
+	clusterUserRoles = slice.Filter(clusterUserRoles, func(index int, item *models.ClusterUserRole) bool {
+		return item.BlacklistNamespaces != "" && item.Cluster == selectedCluster
+	})
+
+	// 如果没有黑名单配置，直接返回原列表
+	if len(clusterUserRoles) == 0 {
+		return list, true
+	}
+
+	// 获取所有黑名单namespace
+	blacklistNs := make(map[string]bool)
+	for _, role := range clusterUserRoles {
+		namespaces := strings.Split(role.BlacklistNamespaces, ",")
+		for _, ns := range namespaces {
+			if ns = strings.TrimSpace(ns); ns != "" {
+				blacklistNs[ns] = true
+			}
+		}
+	}
+
+	// 从列表中剔除黑名单namespace
+	result := slice.Filter(list, func(index int, item map[string]string) bool {
+		ns := item["value"]
+		return !blacklistNs[ns]
+	})
+
+	return result, true
+}
+
+// sortAndRespond 对命名空间列表进行去重、排序并返回响应
+// 每个list item中都有一个map，key为label和value，value为命名空间名称
 func sortAndRespond(c *gin.Context, list []map[string]string) {
+	// 使用map进行去重
+	uniqMap := make(map[string]map[string]string)
+	for _, item := range list {
+		uniqMap[item["value"]] = item
+	}
+
+	// 转换回切片
+	list = make([]map[string]string, 0, len(uniqMap))
+	for _, item := range uniqMap {
+		list = append(list, item)
+	}
+	klog.V(6).Infof("ns list: %v", list)
+
+	selectedCluster, err := amis.GetSelectedCluster(c)
+	if err != nil {
+		amis.WriteJsonError(c, err)
+		return
+	}
+	// 剔除黑名单Namespace
+	list, _ = handleBlacklist(c, selectedCluster, list)
 
 	slice.SortBy(list, func(a, b map[string]string) bool {
 		return a["label"] < b["label"]

--- a/pkg/models/cluster_user_role.go
+++ b/pkg/models/cluster_user_role.go
@@ -13,15 +13,16 @@ import (
 // AuthorizationType有两种类型（user、user_group），如果是用户，那么代表这个人有哪些权限
 // 如果是Group，那么代表这个组有哪些权限，这个组可能会有多个用户，那么这多个用户都有相关的权限
 type ClusterUserRole struct {
-	ID                uint                               `gorm:"primaryKey;autoIncrement" json:"id,omitempty"`
-	Cluster           string                             `gorm:"index" json:"cluster,omitempty"`    // 集群名称
-	Username          string                             `gorm:"index" json:"username,omitempty"`   // 用户名
-	Role              string                             `gorm:"index" json:"role,omitempty"`       // 角色类型：只读、读写、Exec
-	Namespaces        string                             `json:"namespaces,omitempty"`              // Namespaces列表，逗号分割 ，该用户可以访问的Ns
-	AuthorizationType constants.ClusterAuthorizationType `json:"authorization_type,omitempty"`      // 用户类型。User\Group两种，默认为User，空为User。Group指用户组
-	CreatedBy         string                             `gorm:"index" json:"created_by,omitempty"` // 创建者
-	CreatedAt         time.Time                          `json:"created_at,omitempty"`
-	UpdatedAt         time.Time                          `json:"updated_at,omitempty"`
+	ID                  uint                               `gorm:"primaryKey;autoIncrement" json:"id,omitempty"`
+	Cluster             string                             `gorm:"index" json:"cluster,omitempty"`    // 集群名称
+	Username            string                             `gorm:"index" json:"username,omitempty"`   // 用户名
+	Role                string                             `gorm:"index" json:"role,omitempty"`       // 角色类型：只读、读写、Exec
+	Namespaces          string                             `json:"namespaces,omitempty"`              // Namespaces列表，逗号分割 ，该用户可以访问的Ns
+	BlacklistNamespaces string                             `json:"blacklist_namespaces,omitempty"`    // 黑名单Namespaces列表，逗号分割，禁止访问的Ns
+	AuthorizationType   constants.ClusterAuthorizationType `json:"authorization_type,omitempty"`      // 用户类型。User\Group两种，默认为User，空为User。Group指用户组
+	CreatedBy           string                             `gorm:"index" json:"created_by,omitempty"` // 创建者
+	CreatedAt           time.Time                          `json:"created_at,omitempty"`
+	UpdatedAt           time.Time                          `json:"updated_at,omitempty"`
 }
 
 func (c *ClusterUserRole) List(params *dao.Params, queryFuncs ...func(*gorm.DB) *gorm.DB) ([]*ClusterUserRole, int64, error) {

--- a/ui/public/pages/admin/cluster/cluster_all.json
+++ b/ui/public/pages/admin/cluster/cluster_all.json
@@ -696,7 +696,7 @@
                     "closeOnEsc": true,
                     "closeOnOutside": true,
                     "title": "$clusterName 已授权用户列表  (ESC 关闭)",
-                    "size": "lg",
+                    "size": "xl",
                     "body": [
                       {
                         "type": "alert",
@@ -766,9 +766,16 @@
                           },
                           {
                             "name": "namespaces",
-                            "label": "限制命名空间",
+                            "label": "白名单命名空间",
                             "type": "tpl",
                             "tpl": "${namespaces | split:',')}",
+                            "placeholder": "-"
+                          },
+                          {
+                            "name": "blacklist_namespaces",
+                            "label": "黑名单命名空间",
+                            "type": "tpl",
+                            "tpl": "${blacklist_namespaces | split:',')}",
                             "placeholder": "-"
                           },
                           {

--- a/ui/public/pages/admin/cluster/cluster_all.json
+++ b/ui/public/pages/admin/cluster/cluster_all.json
@@ -96,7 +96,7 @@
                   {
                     "type": "alert",
                     "level": "success",
-                    "body": "<div class='alert alert-info'><p><strong>普通用户需要授权，不授权看不到任何集群。授权规则如下：</strong></p><p><strong>集群管理员：</strong>可以管理和操作所有集群资源，包括创建、修改、删除、Exec等操作。</p><p><strong>集群只读：</strong>仅可查看集群资源信息，无法进行修改操作。</p><p><strong>Exec权限：</strong>具有进入容器内，执行命令的权限</p><p><strong>限制命名空间：</strong>置空表示不限制，可访问该集群下所有的命名空间。如果填写了，那么用户就只能访问指定的命名空间了。</p><p><strong>授权类型：</strong>可以为用户、用户组分别授权，当为用户组时，对组内所有用户生效操作。</p></div>"
+                    "body": "<div class='alert alert-info'><p><strong>普通用户需要授权，不授权看不到任何集群。请小心设置权限，避免交叉。授权规则如下：</strong></p><p><strong>集群管理员：</strong>可以管理和操作所有集群资源，包括创建、修改、删除、Exec等操作。</p><p><strong>集群只读：</strong>仅可查看集群资源信息，无法进行修改操作。</p><p><strong>Exec权限：</strong>具有进入容器内，执行命令的权限</p><p><strong>白名单命名空间：</strong>置空表示不限制，可访问该集群下所有的命名空间。如果填写了，那么用户就只能访问指定的命名空间了。</p><p><strong>黑名单命名空间：</strong>置空表示不限制，如果填写了，那么用户将不能访问该命名空间。黑名单可否定白名单。黑名单权限最高。</p><p><strong>授权类型：</strong>可以为用户、用户组分别授权，当为用户组时，对组内所有用户生效操作。</p></div>"
                   },
                   {
                     "type": "tabs",
@@ -411,14 +411,14 @@
                               },
                               {
                                 "name": "namespaces",
-                                "label": "限制命名空间",
+                                "label": "命名空间白名单",
                                 "type": "tpl",
                                 "tpl": "${namespaces | split:',')}",
                                 "placeholder": "-"
                               },
                               {
                                 "type": "button",
-                                "label": "选择命名空间",
+                                "label": "命名空间白名单",
                                 "actionType": "dialog",
                                 "dialog": {
                                   "closeOnEsc": true,
@@ -432,6 +432,37 @@
                                       {
                                         "type": "transfer",
                                         "name": "namespaces",
+                                        "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
+                                        "searchable": true,
+                                        "selectMode": "list"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "name": "blacklist_namespaces",
+                                "label": "命名空间黑名单",
+                                "type": "tpl",
+                                "tpl": "${blacklist_namespaces | split:',')}",
+                                "placeholder": "-"
+                              },
+                              {
+                                "type": "button",
+                                "label": "命名空间黑名单",
+                                "actionType": "dialog",
+                                "dialog": {
+                                  "closeOnEsc": true,
+                                  "closeOnOutside": true,
+                                  "size": "lg",
+                                  "title": "选择命名空间黑名单",
+                                  "body": {
+                                    "type": "form",
+                                    "api": "post:/admin/cluster_permissions/update_blacklist_namespaces/$id",
+                                    "body": [
+                                      {
+                                        "type": "transfer",
+                                        "name": "blacklist_namespaces",
                                         "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
                                         "searchable": true,
                                         "selectMode": "list"
@@ -572,14 +603,14 @@
                               },
                               {
                                 "name": "namespaces",
-                                "label": "限制命名空间",
+                                "label": "命名空间白名单",
                                 "type": "tpl",
                                 "tpl": "${namespaces | split:',')}",
                                 "placeholder": "-"
                               },
                               {
                                 "type": "button",
-                                "label": "选择命名空间",
+                                "label": "命名空间白名单",
                                 "actionType": "dialog",
                                 "dialog": {
                                   "closeOnEsc": true,
@@ -593,6 +624,37 @@
                                       {
                                         "type": "transfer",
                                         "name": "namespaces",
+                                        "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
+                                        "searchable": true,
+                                        "selectMode": "list"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "name": "blacklist_namespaces",
+                                "label": "命名空间黑名单",
+                                "type": "tpl",
+                                "tpl": "${blacklist_namespaces | split:',')}",
+                                "placeholder": "-"
+                              },
+                              {
+                                "type": "button",
+                                "label": "命名空间黑名单",
+                                "actionType": "dialog",
+                                "dialog": {
+                                  "closeOnEsc": true,
+                                  "closeOnOutside": true,
+                                  "size": "lg",
+                                  "title": "选择命名空间黑名单",
+                                  "body": {
+                                    "type": "form",
+                                    "api": "post:/admin/cluster_permissions/update_blacklist_namespaces/$id",
+                                    "body": [
+                                      {
+                                        "type": "transfer",
+                                        "name": "blacklist_namespaces",
                                         "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
                                         "searchable": true,
                                         "selectMode": "list"

--- a/ui/public/pages/admin/cluster/cluster_all.json
+++ b/ui/public/pages/admin/cluster/cluster_all.json
@@ -219,14 +219,14 @@
                               },
                               {
                                 "name": "namespaces",
-                                "label": "限制命名空间",
+                                "label": "命名空间白名单",
                                 "type": "tpl",
                                 "tpl": "${namespaces | split:',')}",
                                 "placeholder": "-"
                               },
                               {
                                 "type": "button",
-                                "label": "选择命名空间",
+                                "label": "命名空间白名单",
                                 "actionType": "dialog",
                                 "dialog": {
                                   "closeOnEsc": true,
@@ -240,6 +240,37 @@
                                       {
                                         "type": "transfer",
                                         "name": "namespaces",
+                                        "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
+                                        "searchable": true,
+                                        "selectMode": "list"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "name": "blacklist_namespaces",
+                                "label": "命名空间黑名单",
+                                "type": "tpl",
+                                "tpl": "${blacklist_namespaces | split:',')}",
+                                "placeholder": "-"
+                              },
+                              {
+                                "type": "button",
+                                "label": "命名空间黑名单",
+                                "actionType": "dialog",
+                                "dialog": {
+                                  "closeOnEsc": true,
+                                  "closeOnOutside": true,
+                                  "size": "lg",
+                                  "title": "选择命名空间黑名单",
+                                  "body": {
+                                    "type": "form",
+                                    "api": "post:/admin/cluster_permissions/update_blacklist_namespaces/$id",
+                                    "body": [
+                                      {
+                                        "type": "transfer",
+                                        "name": "blacklist_namespaces",
                                         "source": "get:/admin/cluster_permissions/cluster/${cluster_id_base64}/ns/list",
                                         "searchable": true,
                                         "selectMode": "list"

--- a/ui/public/pages/user/profile/my_clusters.json
+++ b/ui/public/pages/user/profile/my_clusters.json
@@ -12,7 +12,7 @@
     {
       "type": "alert",
       "level": "success",
-      "body": "<div class='alert alert-info'><p><strong>我已经获得集群授权情况。权限解释：</strong></p><p><strong>集群管理员：</strong>可以管理和操作所有集群资源，包括创建、修改、删除、Exec等操作。</p><p><strong>集群只读：</strong>仅可查看集群资源信息，无法进行修改操作。</p><p><strong>Exec权限：</strong>具有进入容器内，执行命令的权限</p><p><strong>限制命名空间：</strong>置空表示不限制，可访问该集群下所有的命名空间。如果填写了，那么用户就只能访问指定的命名空间了。</p><p><strong>授权类型：</strong>可以为用户、用户组分别授权，当为用户组时，对组内所有用户生效操作。</p></div>"
+      "body": "<div class='alert alert-info'><p><strong>我已经获得集群授权情况。权限解释：</strong></p><p><strong>集群管理员：</strong>可以管理和操作所有集群资源，包括创建、修改、删除、Exec等操作。</p><p><strong>集群只读：</strong>仅可查看集群资源信息，无法进行修改操作。</p><p><strong>Exec权限：</strong>具有进入容器内，执行命令的权限</p><p><strong>白名单命名空间：</strong>置空表示不限制，可访问该集群下所有的命名空间。如果填写了，那么用户就只能访问指定的命名空间了。</p><p><strong>黑名单命名空间：</strong>置空表示不限制，如果填写了，那么用户将不能访问该命名空间。黑名单可否定白名单。黑名单权限最高。</p><p><strong>授权类型：</strong>可以为用户、用户组分别授权，当为用户组时，对组内所有用户生效操作。</p></div>"
     },
     {
       "type": "crud",
@@ -63,9 +63,16 @@
         },
         {
           "name": "namespaces",
-          "label": "限制命名空间",
+          "label": "白名单命名空间",
           "type": "tpl",
           "tpl": "${namespaces | split:',')}",
+          "placeholder": "-"
+        },
+        {
+          "name": "blacklist_namespaces",
+          "label": "黑名单命名空间",
+          "type": "tpl",
+          "tpl": "${blacklist_namespaces | split:',')}",
           "placeholder": "-"
         },
         {


### PR DESCRIPTION
白名单命名空间：置空表示不限制，可访问该集群下所有的命名空间。如果填写了，那么用户就只能访问指定的命名空间了。

黑名单命名空间：置空表示不限制，如果填写了，那么用户将不能访问该命名空间。黑名单可否定白名单。黑名单权限最高。