### PR TITLE
refactor: 统一将模型绑定从指针改为值类型

### DIFF
--- a/pkg/controller/admin/cluster/kubeconfig.go
+++ b/pkg/controller/admin/cluster/kubeconfig.go
@@ -15,7 +15,7 @@ import (
 func SaveKubeConfig(c *gin.Context) {
 
 	params := dao.BuildParams(c)
-	m := &models.KubeConfig{}
+	m := models.KubeConfig{}
 	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)
@@ -77,7 +77,7 @@ func SaveKubeConfig(c *gin.Context) {
 func RemoveKubeConfig(c *gin.Context) {
 
 	params := dao.BuildParams(c)
-	m := &models.KubeConfig{}
+	m := models.KubeConfig{}
 	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/admin/config/condition.go
+++ b/pkg/controller/admin/config/condition.go
@@ -22,7 +22,7 @@ func ConditionList(c *gin.Context) {
 
 func ConditionSave(c *gin.Context) {
 	params := dao.BuildParams(c)
-	m := &models.ConditionReverse{}
+	m := models.ConditionReverse{}
 	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/admin/config/sso.go
+++ b/pkg/controller/admin/config/sso.go
@@ -23,7 +23,7 @@ func SSOConfigList(c *gin.Context) {
 
 func SSOConfigSave(c *gin.Context) {
 	params := dao.BuildParams(c)
-	m := &models.SSOConfig{}
+	m := models.SSOConfig{}
 	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/admin/inspection/scripts.go
+++ b/pkg/controller/admin/inspection/scripts.go
@@ -23,7 +23,7 @@ func LuaScriptList(c *gin.Context) {
 }
 func LuaScriptSave(c *gin.Context) {
 	params := dao.BuildParams(c)
-	m := &models.InspectionLuaScript{}
+	m := models.InspectionLuaScript{}
 	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/admin/user/user.go
+++ b/pkg/controller/admin/user/user.go
@@ -31,7 +31,7 @@ func List(c *gin.Context) {
 }
 func Save(c *gin.Context) {
 	params := dao.BuildParams(c)
-	m := &models.User{}
+	m := models.User{}
 	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)
@@ -81,8 +81,8 @@ func UpdatePsw(c *gin.Context) {
 
 	id := c.Param("id")
 	params := dao.BuildParams(c)
-	m := &models.User{}
-	err := c.ShouldBindJSON(m)
+	m := models.User{}
+	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return

--- a/pkg/controller/admin/user/user_group.go
+++ b/pkg/controller/admin/user/user_group.go
@@ -27,7 +27,7 @@ func ListUserGroup(c *gin.Context) {
 func SaveUserGroup(c *gin.Context) {
 
 	params := dao.BuildParams(c)
-	m := &models.UserGroup{}
+	m := models.UserGroup{}
 	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/template/template.go
+++ b/pkg/controller/template/template.go
@@ -20,7 +20,7 @@ func ListTemplate(c *gin.Context) {
 }
 func SaveTemplate(c *gin.Context) {
 	params := dao.BuildParams(c)
-	m := &models.CustomTemplate{}
+	m := models.CustomTemplate{}
 	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/user/profile/profile.go
+++ b/pkg/controller/user/profile/profile.go
@@ -45,8 +45,8 @@ func ListUserPermissions(c *gin.Context) {
 
 func UpdatePsw(c *gin.Context) {
 	params := dao.BuildParams(c)
-	m := &models.User{}
-	err := c.ShouldBindJSON(m)
+	m := models.User{}
+	err := c.ShouldBindJSON(&m)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return


### PR DESCRIPTION
修改多个控制器中的模型绑定方式，从使用指针改为直接使用值类型
确保JSON绑定的一致性并减少潜在的空指针风险