### PR TITLE
feat(用户管理): 添加用户禁用功能及相关接口

### DIFF
--- a/pkg/cb/cb.go
+++ b/pkg/cb/cb.go
@@ -142,30 +142,30 @@ func handleCommonLogic(k8s *kom.Kubectl, action string) (string, []string, error
 				// 具备只读+Exec权限了，那么继续看是否有该ns的权限.
 				// ns为空，或者ns列表中含有当前ns，那么就允许执行。
 
-				//首先看是否在ns黑名单中，在的话阻止
+				// 首先看是否在ns黑名单中，在的话阻止
 				execClustersWithBNs := slice.Filter(execClusters, func(index int, item *models.ClusterUserRole) bool {
 					return item.BlacklistNamespaces != "" && utils.AnyIn(nsList, strings.Split(item.BlacklistNamespaces, ","))
 				})
 				if len(execClustersWithBNs) > 0 {
-					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限-命名空间黑名单", username, cluster, strings.Join(nsList, ","))
+					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限-进入命名空间黑名单", username, cluster, strings.Join(nsList, ","))
 				}
 				execClustersWithNs := slice.Filter(execClusters, func(index int, item *models.ClusterUserRole) bool {
 					return item.Namespaces == "" || utils.AllIn(nsList, strings.Split(item.Namespaces, ","))
 				})
 				if len(execClustersWithNs) == 0 {
-					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限", username, cluster, strings.Join(nsList, ","))
+					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限-不在命名空间白名单", username, cluster, strings.Join(nsList, ","))
 				}
 			}
 		} else {
 			//  有集群权限，那么继续看是否有该ns的权限.
 			if len(nsList) > 0 {
 
-				//首先看是否在ns黑名单中，在的话阻止
+				// 首先看是否在ns黑名单中，在的话阻止
 				execClustersWithBNs := slice.Filter(manageClusters, func(index int, item *models.ClusterUserRole) bool {
 					return item.BlacklistNamespaces != "" && utils.AnyIn(nsList, strings.Split(item.BlacklistNamespaces, ","))
 				})
 				if len(execClustersWithBNs) > 0 {
-					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限-命名空间黑名单", username, cluster, strings.Join(nsList, ","))
+					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限-进入命名空间黑名单", username, cluster, strings.Join(nsList, ","))
 				}
 
 				// ns为空，或者ns列表中含有当前ns，那么就允许执行。
@@ -173,7 +173,7 @@ func handleCommonLogic(k8s *kom.Kubectl, action string) (string, []string, error
 					return item.Namespaces == "" || utils.AllIn(nsList, strings.Split(item.Namespaces, ","))
 				})
 				if len(execClustersWithNs) == 0 {
-					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限", username, cluster, strings.Join(nsList, ","))
+					return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] Exec权限-不在命名空间白名单", username, cluster, strings.Join(nsList, ","))
 				}
 			}
 		}
@@ -189,19 +189,19 @@ func handleCommonLogic(k8s *kom.Kubectl, action string) (string, []string, error
 			// 具备操作权限了，那么继续看是否有该ns的权限.
 			// ns为空，或者ns列表中含有当前ns，那么就允许执行。
 
-			//首先看是否在ns黑名单中，在的话阻止
+			// 首先看是否在ns黑名单中，在的话阻止
 			execClustersWithBNs := slice.Filter(changeClusters, func(index int, item *models.ClusterUserRole) bool {
 				return item.BlacklistNamespaces != "" && utils.AnyIn(nsList, strings.Split(item.BlacklistNamespaces, ","))
 			})
 			if len(execClustersWithBNs) > 0 {
-				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 操作权限-命名空间黑名单", username, cluster, strings.Join(nsList, ","))
+				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 操作权限-进入命名空间黑名单", username, cluster, strings.Join(nsList, ","))
 			}
 
 			changeClustersWithNs := slice.Filter(changeClusters, func(index int, item *models.ClusterUserRole) bool {
 				return item.Namespaces == "" || utils.AllIn(nsList, strings.Split(item.Namespaces, ","))
 			})
 			if len(changeClustersWithNs) == 0 {
-				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 操作权限", username, cluster, strings.Join(nsList, ","))
+				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 操作权限-不在命名空间白名单", username, cluster, strings.Join(nsList, ","))
 			}
 		}
 	default:
@@ -218,19 +218,19 @@ func handleCommonLogic(k8s *kom.Kubectl, action string) (string, []string, error
 			// 具备操作权限了，那么继续看是否有该ns的权限.
 			// ns为空，或者ns列表中含有当前ns，那么就允许执行。
 
-			//首先看是否在ns黑名单中，在的话阻止
+			// 首先看是否在ns黑名单中，在的话阻止
 			execClustersWithBNs := slice.Filter(readClusters, func(index int, item *models.ClusterUserRole) bool {
 				return item.BlacklistNamespaces != "" && utils.AnyIn(nsList, strings.Split(item.BlacklistNamespaces, ","))
 			})
 			if len(execClustersWithBNs) > 0 {
-				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 读取权限-命名空间黑名单", username, cluster, strings.Join(nsList, ","))
+				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 读取权限-进入命名空间黑名单", username, cluster, strings.Join(nsList, ","))
 			}
 
 			readClustersWithNs := slice.Filter(readClusters, func(index int, item *models.ClusterUserRole) bool {
 				return item.Namespaces == "" || utils.AllIn(nsList, strings.Split(item.Namespaces, ","))
 			})
 			if len(readClustersWithNs) == 0 {
-				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 读取权限", username, cluster, strings.Join(nsList, ","))
+				return "", nil, fmt.Errorf("用户[%s]没有集群[%s] [%s] 读取权限-不在命名空间白名单", username, cluster, strings.Join(nsList, ","))
 			}
 		}
 	}

--- a/pkg/controller/admin/config/condition.go
+++ b/pkg/controller/admin/config/condition.go
@@ -64,7 +64,7 @@ func ConditionQuickSave(c *gin.Context) {
 	} else {
 		entity.Enabled = false
 	}
-	err := dao.DB().Model(&entity).Select("Enabled").Updates(entity).Error
+	err := dao.DB().Model(&entity).Select("Disabled").Updates(entity).Error
 
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/admin/mcp/mcp_tools.go
+++ b/pkg/controller/admin/mcp/mcp_tools.go
@@ -58,7 +58,7 @@ func (m *MCPToolController) ToolQuickSave(c *gin.Context) {
 	} else {
 		entity.Enabled = false
 	}
-	err := dao.DB().Model(&entity).Select("Enabled").Updates(entity).Error
+	err := dao.DB().Model(&entity).Select("Disabled").Updates(entity).Error
 
 	if err != nil {
 		amis.WriteJsonError(c, err)

--- a/pkg/controller/login/login.go
+++ b/pkg/controller/login/login.go
@@ -28,7 +28,7 @@ type LoginRequest struct {
 
 func LoginByPassword(c *gin.Context) {
 	var req LoginRequest
-	errorInfo := gin.H{"message": "用户名或密码错误"}
+	errorInfo := gin.H{"message": "用户名密码错误或用户被禁用"}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		klog.Errorf("LoginByPassword %v", err.Error())
 		c.JSON(http.StatusUnauthorized, errorInfo)
@@ -70,6 +70,13 @@ func LoginByPassword(c *gin.Context) {
 		}
 		for _, v := range list {
 			if v.Username == req.Username {
+
+				if v.Disabled {
+					klog.Errorf("用户[%s]被禁用", v.Username)
+					c.JSON(http.StatusUnauthorized, errorInfo)
+					return
+				}
+
 				// password base64解密
 				// 前端密码解密的值，加上盐值，重新计算
 				decryptPsw, err := utils.AesEncrypt([]byte(fmt.Sprintf("%s%s", string(decrypt), v.Salt)))

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -23,7 +23,7 @@ type User struct {
 	TwoFASecret      string    `gorm:"size:100" json:"two_fa_secret,omitempty"`       // 2FA密钥
 	TwoFABackupCodes string    `gorm:"size:500" json:"two_fa_backup_codes,omitempty"` // 备用恢复码，逗号分隔
 	TwoFAAppName     string    `gorm:"size:100" json:"two_fa_app_name,omitempty"`     // 2FA应用名称，用于提醒用户使用的是哪个软件
-
+	Disabled         bool      `gorm:"default:false" json:"disabled,omitempty"`       // 是否启用
 }
 
 func (c *User) List(params *dao.Params, queryFuncs ...func(*gorm.DB) *gorm.DB) ([]*User, int64, error) {
@@ -41,4 +41,13 @@ func (c *User) Delete(params *dao.Params, ids string, queryFuncs ...func(*gorm.D
 
 func (c *User) GetOne(params *dao.Params, queryFuncs ...func(*gorm.DB) *gorm.DB) (*User, error) {
 	return dao.GenericGetOne(params, c, queryFuncs...)
+}
+
+func (c *User) IsDisabled(username string) (bool, error) {
+	err := dao.DB().Model(c).Select("disabled").Where(" username = ?", username).First(&c).Error
+	if err != nil {
+		return false, err
+	}
+
+	return c.Disabled, nil
 }

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -42,12 +42,13 @@ func (c *User) Delete(params *dao.Params, ids string, queryFuncs ...func(*gorm.D
 func (c *User) GetOne(params *dao.Params, queryFuncs ...func(*gorm.DB) *gorm.DB) (*User, error) {
 	return dao.GenericGetOne(params, c, queryFuncs...)
 }
-
+ 
 func (c *User) IsDisabled(username string) (bool, error) {
-	err := dao.DB().Model(c).Select("disabled").Where(" username = ?", username).First(&c).Error
+	var user User
+	err := dao.DB().Model(c).Select("disabled").Where("username = ?", username).First(&user).Error
 	if err != nil {
 		return false, err
 	}
 
-	return c.Disabled, nil
+	return user.Disabled, nil
 }

--- a/ui/public/pages/admin/user/user.json
+++ b/ui/public/pages/admin/user/user.json
@@ -120,6 +120,7 @@
         }
       ],
       "api": "get:/admin/user/list",
+      "quickSaveItemApi": "/admin/user/save/id/${id}/status/${disabled}",
       "columns": [
         {
           "type": "operation",
@@ -380,6 +381,16 @@
               }
             }
           ]
+        },
+        {
+          "name": "disabled",
+          "label": "禁用",
+          "quickEdit": {
+            "mode": "inline",
+            "type": "switch",
+            "saveImmediately": true,
+            "resetOnFailed": true
+          }
         },
         {
           "label": "来源",


### PR DESCRIPTION
实现用户禁用功能，包括：
- 在用户模型中添加disabled字段
- 添加用户状态快速保存接口
- 在登录和MCP密钥验证时检查用户禁用状态
- 更新错误提示信息更明确
- 添加前端用户列表的禁用开关和快速保存功能