### PR TITLE
OpenKruise支持

### DIFF
--- a/ui/public/pages/openkruise/PodUnavailableBudget.json
+++ b/ui/public/pages/openkruise/PodUnavailableBudget.json
@@ -1,0 +1,715 @@
+{
+  "type": "page",
+  "data": {
+    "ns": "${ls:selectedNs||'default'}",
+    "kind": "PodUnavailableBudget",
+    "group": "apps.kruise.io",
+    "version": "v1alpha1"
+  },
+  "body": [
+    {
+      "type": "container",
+      "className": "floating-toolbar",
+      "body": [
+        {
+          "type": "tpl",
+          "tpl": "${kind}",
+          "className": "mr-2"
+        },
+        {
+          "type": "button",
+          "label": "属性文档",
+          "level": "link",
+          "icon": "fas fa-book-open text-primary",
+          "actionType": "drawer",
+          "drawer": {
+            "overlay": false,
+            "closeOnEsc": true,
+            "closeOnOutside": true,
+            "size": "lg",
+            "title": "${kind} 属性文档（ESC 关闭）",
+            "body": [
+              {
+                "type": "page",
+                "asideResizor": true,
+                "asideSticky": false,
+                "aside": [
+                  {
+                    "type": "input-tree",
+                    "name": "tree",
+                    "initiallyOpen": false,
+                    "unfoldedLevel": 1,
+                    "searchable": true,
+                    "showOutline": true,
+                    "showIcon": true,
+                    "searchConfig": {
+                      "sticky": true
+                    },
+                    "heightAuto": true,
+                    "inputClassName": "no-border no-padder mt-1",
+                    "source": "get:/k8s/doc/kind/$kind/group/$group/version/$version",
+                    "onEvent": {
+                      "change": {
+                        "actions": [
+                          {
+                            "componentId": "basic",
+                            "actionType": "reload",
+                            "data": {
+                              "description": "${event.data.item.description}",
+                              "id": "${event.data.item.id}",
+                              "full_id": "${event.data.item.full_id}",
+                              "type": "${event.data.item.type}"
+                            }
+                          },
+                          {
+                            "componentId": "detail",
+                            "actionType": "reload",
+                            "data": {
+                              "description": "${event.data.item.description}",
+                              "id": "${event.data.item.id}",
+                              "full_id": "${event.data.item.full_id}",
+                              "type": "${event.data.item.type}"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "body": [
+                  {
+                    "type": "service",
+                    "id": "basic",
+                    "body": [
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>属性：</strong> ${id}",
+                        "visibleOn": "${id}"
+                      },
+                      {
+                        "type": "button",
+                        "label": "示例",
+                        "level": "link",
+                        "icon": "fas fa-lightbulb text-warning",
+                        "actionType": "drawer",
+                        "drawer": {
+                          "overlay": false,
+                          "closeOnEsc": true,
+                          "closeOnOutside": true,
+                          "size": "lg",
+                          "title": "${kind}-${id} 参考样例（ESC 关闭）",
+                          "body": [
+                            {
+                              "type": "websocketMarkdownViewer",
+                              "url": "/ai/chat/example/field",
+                              "params": {
+                                "kind": "${kind}",
+                                "group": "${group}",
+                                "version": "${version}",
+                                "field": "${full_id}"
+                              }
+                            }
+                          ]
+                        },
+                        "visibleOn": "${id}"
+                      },
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>类型：</strong> <span class='label label-primary'>${type}</span>",
+                        "visibleOn": "${type}"
+                      },
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>描述：</strong> ${description}",
+                        "visibleOn": "${description}"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "service",
+                    "id": "detail",
+                    "api": "post:/k8s/doc/detail",
+                    "body": [
+                      {
+                        "type": "divider",
+                        "title": "描述翻译",
+                        "titlePosition": "center",
+                        "visibleOn": "${translate}"
+                      },
+                      {
+                        "type": "markdown",
+                        "value": "${translate|raw}",
+                        "options": {
+                          "linkify": true,
+                          "html": true,
+                          "breaks": true
+                        },
+                        "visibleOn": "${translate}"
+                      },
+                      {
+                        "type": "container",
+                        "body": [
+                          {
+                            "type": "tpl",
+                            "tpl": "<div style='height:80vh'>&nbsp</div>"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "label": "指南",
+          "level": "link",
+          "icon": "fas fa-lightbulb text-primary",
+          "actionType": "drawer",
+          "drawer": {
+            "overlay": false,
+            "closeOnEsc": true,
+            "closeOnOutside": true,
+            "size": "lg",
+            "title": "${kind} 参考样例（ESC 关闭）",
+            "body": [
+              {
+                "type": "websocketMarkdownViewer",
+                "url": "/ai/chat/example",
+                "params": {
+                  "kind": "${kind}",
+                  "group": "${group}",
+                  "version": "${version}"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "label": "创建",
+          "icon": "fas fa-dharmachakra text-primary",
+          "type": "button",
+          "level": "link",
+          "actionType": "url",
+          "blank": true,
+          "url": "/#/apply/apply?kind=${kind}"
+        }
+      ]
+    },
+    {
+      "type": "container",
+      "className": "floating-toolbar-right",
+      "body": [
+        {
+          "type": "wrapper",
+          "body": [
+            {
+              "type": "form",
+              "mode": "inline",
+              "wrapWithPanel": false,
+              "body": [
+                {
+                  "label": "命名空间",
+                  "type": "select",
+                  "multiple": true,
+                  "maxTagCount": 1,
+                  "name": "ns",
+                  "id": "ns",
+                  "searchable": true,
+                  "checkAll": true,
+                  "source": "/k8s/ns/option_list",
+                  "value": "${ls:selectedNs||'default'}",
+                  "onEvent": {
+                    "change": {
+                      "actions": [
+                        {
+                          "actionType": "reload",
+                          "componentId": "detailCRUD",
+                          "data": {
+                            "ns": "${ns}"
+                          }
+                        },
+                        {
+                          "actionType": "custom",
+                          "script": "localStorage.setItem('selectedNs', event.data.ns)"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "label": "集群",
+                  "type": "select",
+                  "multiple": false,
+                  "name": "cluster",
+                  "id": "cluster",
+                  "searchable": true,
+                  "source": "/params/cluster/option_list",
+                  "value": "${ls:cluster}",
+                  "onEvent": {
+                    "change": {
+                      "actions": [
+                        {
+                          "actionType": "custom",
+                          "script": "localStorage.setItem('cluster', event.data.value)"
+                        },
+                        {
+                          "actionType": "custom",
+                          "script": "window.location.reload();"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "crud",
+      "id": "detailCRUD",
+      "name": "detailCRUD",
+      "autoFillHeight": true,
+      "autoGenerateFilter": {
+        "columnsNum": 4,
+        "showBtnToolbar": false
+      },
+      "headerToolbar": [
+        {
+          "type": "columns-toggler",
+          "align": "right",
+          "draggable": true,
+          "icon": "fas fa-cog",
+          "overlay": true,
+          "footerBtnSize": "sm"
+        },
+        {
+          "type": "tpl",
+          "tpl": "共${count}条",
+          "align": "right",
+          "visibleOn": "${count}"
+        },
+        {
+          "type": "columns-toggler",
+          "align": "left"
+        },
+        "reload",
+        "bulkActions"
+      ],
+      "loadDataOnce": false,
+      "syncLocation": false,
+      "initFetch": true,
+      "perPage": 10,
+      "bulkActions": [
+        {
+          "label": "批量删除",
+          "actionType": "ajax",
+          "confirmText": "确定要批量删除?",
+          "api": {
+            "url": "/k8s/$kind/group/$group/version/$version/batch/remove",
+            "method": "post",
+            "data": {
+              "name_list": "${selectedItems | pick:metadata.name }",
+              "ns_list": "${selectedItems | pick:metadata.namespace }"
+            }
+          }
+        },
+        {
+          "label": "强制删除",
+          "actionType": "ajax",
+          "confirmText": "确定要批量强制删除?",
+          "api": {
+            "url": "/k8s/$kind/group/$group/version/$version/force_remove",
+            "method": "post",
+            "data": {
+              "name_list": "${selectedItems | pick:metadata.name }",
+              "ns_list": "${selectedItems | pick:metadata.namespace }"
+            }
+          }
+        }
+      ],
+      "footerToolbar": [
+        {
+          "type": "pagination",
+          "align": "right"
+        },
+        {
+          "type": "statistics",
+          "align": "right"
+        },
+        {
+          "type": "switch-per-page",
+          "align": "right"
+        }
+      ],
+      "api": "post:/k8s/$kind/group/$group/version/$version/list/ns/${ns}",
+      "columns": [
+        {
+          "type": "operation",
+          "label": "操作",
+          "width": 120,
+          "buttons": [
+            {
+              "type": "button",
+              "icon": "fas fa-eye text-primary",
+              "actionType": "drawer",
+              "tooltip": "资源描述",
+              "drawer": {
+                "closeOnEsc": true,
+                "closeOnOutside": true,
+                "size": "xl",
+                "title": "Describe: ${metadata.name}  (ESC 关闭)",
+                "body": [
+                  {
+                    "type": "service",
+                    "api": "post:/k8s/$kind/group/$group/version/$version/describe/ns/$metadata.namespace/name/$metadata.name",
+                    "body": [
+                      {
+                        "type": "button",
+                        "label": "AI解读",
+                        "icon": "fas fa-brain text-primary",
+                        "actionType": "drawer",
+                        "drawer": {
+                          "closeOnEsc": true,
+                          "closeOnOutside": true,
+                          "size": "xl",
+                          "title": "AI解读  (ESC 关闭)",
+                          "body": [
+                            {
+                              "type": "websocketMarkdownViewer",
+                              "url": "/ai/chat/describe",
+                              "params": {
+                                "kind": "${kind}",
+                                "group": "${group}",
+                                "version": "${version}",
+                                "name": "${metadata.name}",
+                                "namespace": "${metadata.namespace}"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "highlightHtml",
+                        "keywords": [
+                          "Error",
+                          "Warning"
+                        ],
+                        "html": "${result}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "button",
+              "icon": "fa fa-edit text-primary",
+              "tooltip": "Yaml编辑",
+              "actionType": "drawer",
+              "drawer": {
+                "closeOnEsc": true,
+                "closeOnOutside": true,
+                "size": "lg",
+                "title": "Yaml管理",
+                "body": [
+                  {
+                    "type": "tabs",
+                    "tabsMode": "tiled",
+                    "tabs": [
+                      {
+                        "title": "查看编辑",
+                        "body": [
+                          {
+                            "type": "service",
+                            "api": "get:/k8s/$kind/group/$group/version/$version/ns/$metadata.namespace/name/$metadata.name",
+                            "body": [
+                              {
+                                "type": "mEditor",
+                                "text": "${yaml}",
+                                "componentId": "yaml",
+                                "saveApi": "/k8s/${kind}/group/${group}/version/${version}/update/ns/${metadata.namespace}/name/${metadata.name}",
+                                "options": {
+                                  "language": "yaml",
+                                  "wordWrap": "on",
+                                  "scrollbar": {
+                                    "vertical": "auto"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "文档",
+                        "body": [
+                          {
+                            "type": "page",
+                            "asideResizor": true,
+                            "asideSticky": false,
+                            "aside": [
+                              {
+                                "type": "input-tree",
+                                "name": "tree",
+                                "initiallyOpen": false,
+                                "unfoldedLevel": 1,
+                                "searchable": true,
+                                "showOutline": true,
+                                "showIcon": true,
+                                "searchConfig": {
+                                  "sticky": true
+                                },
+                                "heightAuto": true,
+                                "inputClassName": "no-border no-padder mt-1",
+                                "source": "get:/k8s/doc/gvk/${apiVersion|base64Encode}/$kind",
+                                "onEvent": {
+                                  "change": {
+                                    "actions": [
+                                      {
+                                        "componentId": "basic",
+                                        "actionType": "reload",
+                                        "data": {
+                                          "description": "${event.data.item.description}",
+                                          "id": "${event.data.item.id}",
+                                          "full_id": "${event.data.item.full_id}",
+                                          "type": "${event.data.item.type}"
+                                        }
+                                      },
+                                      {
+                                        "componentId": "detail",
+                                        "actionType": "reload",
+                                        "data": {
+                                          "description": "${event.data.item.description}",
+                                          "id": "${event.data.item.id}",
+                                          "full_id": "${event.data.item.full_id}",
+                                          "type": "${event.data.item.type}"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "body": [
+                              {
+                                "type": "service",
+                                "id": "basic",
+                                "body": [
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>属性：</strong> ${id}",
+                                    "visibleOn": "${id}"
+                                  },
+                                  {
+                                    "type": "button",
+                                    "label": "示例",
+                                    "level": "link",
+                                    "icon": "fas fa-lightbulb text-warning",
+                                    "actionType": "drawer",
+                                    "drawer": {
+                                      "overlay": false,
+                                      "closeOnEsc": true,
+                                      "closeOnOutside": true,
+                                      "size": "lg",
+                                      "title": "${kind}-${id} 参考样例（ESC 关闭）",
+                                      "body": [
+                                        {
+                                          "type": "websocketMarkdownViewer",
+                                          "url": "/ai/chat/example/field",
+                                          "params": {
+                                            "kind": "${kind}",
+                                            "group": "${group}",
+                                            "version": "${version}",
+                                            "field": "${full_id}"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "visibleOn": "${id}"
+                                  },
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>类型：</strong> <span class='label label-primary'>${type}</span>",
+                                    "visibleOn": "${type}"
+                                  },
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>描述：</strong> ${description}",
+                                    "visibleOn": "${description}"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "service",
+                                "id": "detail",
+                                "api": "post:/k8s/doc/detail",
+                                "body": [
+                                  {
+                                    "type": "divider",
+                                    "title": "描述翻译",
+                                    "titlePosition": "center",
+                                    "visibleOn": "${translate}"
+                                  },
+                                  {
+                                    "type": "markdown",
+                                    "value": "${translate|raw}",
+                                    "options": {
+                                      "linkify": true,
+                                      "html": true,
+                                      "breaks": true
+                                    },
+                                    "visibleOn": "${translate}"
+                                  },
+                                  {
+                                    "type": "container",
+                                    "body": [
+                                      {
+                                        "type": "tpl",
+                                        "tpl": "<div style='height:80vh'>&nbsp</div>"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "actions": []
+              }
+            }
+          ],
+          "toggled": true
+        },
+        {
+          "name": "metadata.namespace",
+          "label": "命名空间",
+          "type": "text",
+          "sortable": true
+        },
+        {
+          "name": "metadata.name",
+          "label": "名称",
+          "type": "text",
+          "width": "180px",
+          "sortable": true,
+          "searchable": {
+            "type": "input-text",
+            "name": "metadata.name",
+            "clearable": true,
+            "label": "名称",
+            "placeholder": "输入名称"
+          }
+        },
+        {
+          "label": "目标",
+          "width": "150px",
+          "type": "tpl",
+          "tpl": "[<%= data.spec.targetRef.kind %>]<%= data.spec.targetRef.name %>"
+        },
+        {
+          "name": "状态",
+          "label": "副本可用策略<br><span class='text-gray-500 text-xs'>(两者互斥，优先使用最大不可用)</span>",
+          "type": "tpl",
+          "tpl": "<span style='margin-right: 8px;'><strong>最大不可用:</strong> ${spec.maxUnavailable}</span><span style='margin-right: 8px;'><strong>最小可用:</strong> ${spec.minAvailable}</span>"
+        },
+        {
+          "name": "metadata.labels",
+          "label": "标签",
+          "type": "tpl",
+          "tpl": "${metadata.labels ? '<i class=\"fa fa-tags text-primary\"></i>' : '<i class=\"fa fa-tags text-secondary\"></i>'}",
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "actionType": "dialog",
+                  "dialog": {
+                    "title": "${metadata.name} 标签 (ESC 关闭)",
+                    "name": "dialog_labels",
+                    "size": "lg",
+                    "closeOnEsc": true,
+                    "closeOnOutside": true,
+                    "body": [
+                      {
+                        "type": "form",
+                        "mode": "horizontal",
+                        "labelWidth": 0,
+                        "api": "post:/k8s/$kind/group/$group/version/$version/update_labels/ns/$metadata.namespace/name/$metadata.name",
+                        "body": [
+                          {
+                            "type": "input-kv",
+                            "name": "labels",
+                            "draggable": false,
+                            "value": "${metadata.labels}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "style": {
+            "cursor": "pointer"
+          }
+        },
+        {
+          "name": "metadata.annotations",
+          "label": "注解",
+          "type": "tpl",
+          "tpl": "${metadata.annotations|filterAnnotations|showAnnotationIcon|isTrue:'<i class=\"fa fa-note-sticky text-primary\"></i>':'<i class=\"fa fa-note-sticky text-secondary\"></i>'}",
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "actionType": "dialog",
+                  "dialog": {
+                    "title": "${metadata.name} 注解 (ESC 关闭)",
+                    "name": "dialog_annotations",
+                    "body": [
+                      {
+                        "type": "form",
+                        "mode": "horizontal",
+                        "labelWidth": 0,
+                        "api": "post:/k8s/$kind/group/$group/version/$version/update_annotations/ns/$metadata.namespace/name/$metadata.name",
+                        "initApi": "get:/k8s/$kind/group/$group/version/$version/annotations/ns/$metadata.namespace/name/$metadata.name",
+                        "body": [
+                          {
+                            "type": "input-kv",
+                            "name": "annotations",
+                            "draggable": false,
+                            "value": "${annotations}"
+                          }
+                        ]
+                      }
+                    ],
+                    "size": "lg",
+                    "closeOnEsc": true,
+                    "closeOnOutside": true
+                  }
+                }
+              ]
+            }
+          },
+          "style": {
+            "cursor": "pointer"
+          }
+        },
+        {
+          "name": "metadata.creationTimestamp",
+          "label": "存在时长",
+          "type": "k8sAge"
+        }
+      ]
+    }
+  ]
+}

--- a/ui/public/pages/openkruise/ResourceDistribution.json
+++ b/ui/public/pages/openkruise/ResourceDistribution.json
@@ -1,0 +1,660 @@
+{
+  "type": "page",
+  "data": {
+    "kind": "ResourceDistribution",
+    "group": "apps.kruise.io",
+    "version": "v1alpha1"
+  },
+  "body": [
+    {
+      "type": "container",
+      "className": "floating-toolbar",
+      "body": [
+        {
+          "type": "tpl",
+          "tpl": "${kind}",
+          "className": "mr-2"
+        },
+        {
+          "type": "button",
+          "label": "属性文档",
+          "level": "link",
+          "icon": "fas fa-book-open text-primary",
+          "actionType": "drawer",
+          "drawer": {
+            "overlay": false,
+            "closeOnEsc": true,
+            "closeOnOutside": true,
+            "size": "lg",
+            "title": "${kind} 属性文档（ESC 关闭）",
+            "body": [
+              {
+                "type": "page",
+                "asideResizor": true,
+                "asideSticky": false,
+                "aside": [
+                  {
+                    "type": "input-tree",
+                    "name": "tree",
+                    "initiallyOpen": false,
+                    "unfoldedLevel": 1,
+                    "searchable": true,
+                    "showOutline": true,
+                    "showIcon": true,
+                    "searchConfig": {
+                      "sticky": true
+                    },
+                    "heightAuto": true,
+                    "inputClassName": "no-border no-padder mt-1",
+                    "source": "get:/k8s/doc/kind/$kind/group/$group/version/$version",
+                    "onEvent": {
+                      "change": {
+                        "actions": [
+                          {
+                            "componentId": "basic",
+                            "actionType": "reload",
+                            "data": {
+                              "description": "${event.data.item.description}",
+                              "id": "${event.data.item.id}",
+                              "full_id": "${event.data.item.full_id}",
+                              "type": "${event.data.item.type}"
+                            }
+                          },
+                          {
+                            "componentId": "detail",
+                            "actionType": "reload",
+                            "data": {
+                              "description": "${event.data.item.description}",
+                              "id": "${event.data.item.id}",
+                              "full_id": "${event.data.item.full_id}",
+                              "type": "${event.data.item.type}"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "body": [
+                  {
+                    "type": "service",
+                    "id": "basic",
+                    "body": [
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>属性：</strong> ${id}",
+                        "visibleOn": "${id}"
+                      },
+                      {
+                        "type": "button",
+                        "label": "示例",
+                        "level": "link",
+                        "icon": "fas fa-lightbulb text-warning",
+                        "actionType": "drawer",
+                        "drawer": {
+                          "overlay": false,
+                          "closeOnEsc": true,
+                          "closeOnOutside": true,
+                          "size": "lg",
+                          "title": "${kind}-${id} 参考样例（ESC 关闭）",
+                          "body": [
+                            {
+                              "type": "websocketMarkdownViewer",
+                              "url": "/ai/chat/example/field",
+                              "params": {
+                                "kind": "${kind}",
+                                "group": "${group}",
+                                "version": "${version}",
+                                "field": "${full_id}"
+                              }
+                            }
+                          ]
+                        },
+                        "visibleOn": "${id}"
+                      },
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>类型：</strong> <span class='label label-primary'>${type}</span>",
+                        "visibleOn": "${type}"
+                      },
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>描述：</strong> ${description}",
+                        "visibleOn": "${description}"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "service",
+                    "id": "detail",
+                    "api": "post:/k8s/doc/detail",
+                    "body": [
+                      {
+                        "type": "divider",
+                        "title": "描述翻译",
+                        "titlePosition": "center",
+                        "visibleOn": "${translate}"
+                      },
+                      {
+                        "type": "markdown",
+                        "value": "${translate|raw}",
+                        "options": {
+                          "linkify": true,
+                          "html": true,
+                          "breaks": true
+                        },
+                        "visibleOn": "${translate}"
+                      },
+                      {
+                        "type": "container",
+                        "body": [
+                          {
+                            "type": "tpl",
+                            "tpl": "<div style='height:80vh'>&nbsp</div>"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "label": "指南",
+          "level": "link",
+          "icon": "fas fa-lightbulb text-primary",
+          "actionType": "drawer",
+          "drawer": {
+            "overlay": false,
+            "closeOnEsc": true,
+            "closeOnOutside": true,
+            "size": "lg",
+            "title": "${kind} 参考样例（ESC 关闭）",
+            "body": [
+              {
+                "type": "websocketMarkdownViewer",
+                "url": "/ai/chat/example",
+                "params": {
+                  "kind": "${kind}",
+                  "group": "${group}",
+                  "version": "${version}"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "label": "创建",
+          "icon": "fas fa-dharmachakra text-primary",
+          "type": "button",
+          "level": "link",
+          "actionType": "url",
+          "blank": true,
+          "url": "/#/apply/apply?kind=${kind}"
+        }
+      ]
+    },
+    {
+      "type": "container",
+      "className": "floating-toolbar-right",
+      "body": [
+        {
+          "type": "wrapper",
+          "style": {
+            "display": "inline-flex"
+          },
+          "body": [
+            {
+              "type": "form",
+              "mode": "inline",
+              "wrapWithPanel": false,
+              "body": [
+                {
+                  "label": "集群",
+                  "type": "select",
+                  "multiple": false,
+                  "name": "cluster",
+                  "id": "cluster",
+                  "searchable": true,
+                  "source": "/params/cluster/option_list",
+                  "value": "${ls:cluster}",
+                  "onEvent": {
+                    "change": {
+                      "actions": [
+                        {
+                          "actionType": "custom",
+                          "script": "localStorage.setItem('cluster', event.data.value)"
+                        },
+                        {
+                          "actionType": "custom",
+                          "script": "window.location.reload();"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "crud",
+      "id": "detailCRUD",
+      "name": "detailCRUD",
+      "autoFillHeight": true,
+      "autoGenerateFilter": {
+        "columnsNum": 4,
+        "showBtnToolbar": false
+      },
+      "headerToolbar": [
+        {
+          "type": "columns-toggler",
+          "align": "right",
+          "draggable": true,
+          "icon": "fas fa-cog",
+          "overlay": true,
+          "footerBtnSize": "sm"
+        },
+        {
+          "type": "tpl",
+          "tpl": "共${count}条",
+          "align": "right",
+          "visibleOn": "${count}"
+        },
+        {
+          "type": "columns-toggler",
+          "align": "left"
+        },
+        "reload",
+        "bulkActions"
+      ],
+      "loadDataOnce": false,
+      "syncLocation": false,
+      "perPage": 10,
+      "bulkActions": [
+        {
+          "label": "批量删除",
+          "actionType": "ajax",
+          "confirmText": "确定要批量删除?",
+          "api": {
+            "url": "/k8s/$kind/group/$group/version/$version/batch/remove",
+            "method": "post",
+            "data": {
+              "name_list": "${selectedItems | pick:metadata.name }",
+              "ns_list": "${selectedItems | pick:metadata.namespace }"
+            }
+          }
+        },
+        {
+          "label": "强制删除",
+          "actionType": "ajax",
+          "confirmText": "确定要批量强制删除?",
+          "api": {
+            "url": "/k8s/$kind/group/$group/version/$version/force_remove",
+            "method": "post",
+            "data": {
+              "name_list": "${selectedItems | pick:metadata.name }",
+              "ns_list": "${selectedItems | pick:metadata.namespace }"
+            }
+          }
+        }
+      ],
+      "api": "post:/k8s/$kind/group/$group/version/$version/list",
+      "columns": [
+        {
+          "type": "operation",
+          "label": "操作",
+          "width": 120,
+          "buttons": [
+            {
+              "type": "button",
+              "icon": "fas fa-eye text-primary",
+              "actionType": "drawer",
+              "tooltip": "资源描述",
+              "drawer": {
+                "closeOnEsc": true,
+                "closeOnOutside": true,
+                "size": "xl",
+                "title": "Describe: ${metadata.name}  (ESC 关闭)",
+                "body": [
+                  {
+                    "type": "service",
+                    "api": "post:/k8s/$kind/group/$group/version/$version/describe/ns/$metadata.namespace/name/$metadata.name",
+                    "body": [
+                      {
+                        "type": "button",
+                        "label": "AI解读",
+                        "icon": "fas fa-brain text-primary",
+                        "actionType": "drawer",
+                        "drawer": {
+                          "closeOnEsc": true,
+                          "closeOnOutside": true,
+                          "size": "xl",
+                          "title": "AI解读  (ESC 关闭)",
+                          "body": [
+                            {
+                              "type": "websocketMarkdownViewer",
+                              "url": "/ai/chat/describe",
+                              "params": {
+                                "kind": "${kind}",
+                                "group": "${group}",
+                                "version": "${version}",
+                                "name": "${metadata.name}",
+                                "namespace": "${metadata.namespace}"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "highlightHtml",
+                        "keywords": [
+                          "Error",
+                          "Warning"
+                        ],
+                        "html": "${result}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "button",
+              "icon": "fa fa-edit text-primary",
+              "tooltip": "Yaml编辑",
+              "actionType": "drawer",
+              "drawer": {
+                "closeOnEsc": true,
+                "closeOnOutside": true,
+                "size": "lg",
+                "title": "Yaml管理",
+                "body": [
+                  {
+                    "type": "tabs",
+                    "tabsMode": "tiled",
+                    "tabs": [
+                      {
+                        "title": "查看编辑",
+                        "body": [
+                          {
+                            "type": "service",
+                            "api": "get:/k8s/$kind/group/$group/version/$version/ns/$metadata.namespace/name/$metadata.name",
+                            "body": [
+                              {
+                                "type": "mEditor",
+                                "text": "${yaml}",
+                                "componentId": "yaml",
+                                "saveApi": "/k8s/${kind}/group/${group}/version/${version}/update/ns/${metadata.namespace}/name/${metadata.name}",
+                                "options": {
+                                  "language": "yaml",
+                                  "wordWrap": "on",
+                                  "scrollbar": {
+                                    "vertical": "auto"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "文档",
+                        "body": [
+                          {
+                            "type": "page",
+                            "asideResizor": true,
+                            "asideSticky": false,
+                            "aside": [
+                              {
+                                "type": "input-tree",
+                                "name": "tree",
+                                "initiallyOpen": false,
+                                "unfoldedLevel": 1,
+                                "searchable": true,
+                                "showOutline": true,
+                                "showIcon": true,
+                                "searchConfig": {
+                                  "sticky": true
+                                },
+                                "heightAuto": true,
+                                "inputClassName": "no-border no-padder mt-1",
+                                "source": "get:/k8s/doc/gvk/${apiVersion|base64Encode}/$kind",
+                                "onEvent": {
+                                  "change": {
+                                    "actions": [
+                                      {
+                                        "componentId": "basic",
+                                        "actionType": "reload",
+                                        "data": {
+                                          "description": "${event.data.item.description}",
+                                          "id": "${event.data.item.id}",
+                                          "full_id": "${event.data.item.full_id}",
+                                          "type": "${event.data.item.type}"
+                                        }
+                                      },
+                                      {
+                                        "componentId": "detail",
+                                        "actionType": "reload",
+                                        "data": {
+                                          "description": "${event.data.item.description}",
+                                          "id": "${event.data.item.id}",
+                                          "full_id": "${event.data.item.full_id}",
+                                          "type": "${event.data.item.type}"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "body": [
+                              {
+                                "type": "service",
+                                "id": "basic",
+                                "body": [
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>属性：</strong> ${id}",
+                                    "visibleOn": "${id}"
+                                  },
+                                  {
+                                    "type": "button",
+                                    "label": "示例",
+                                    "level": "link",
+                                    "icon": "fas fa-lightbulb text-warning",
+                                    "actionType": "drawer",
+                                    "drawer": {
+                                      "overlay": false,
+                                      "closeOnEsc": true,
+                                      "closeOnOutside": true,
+                                      "size": "lg",
+                                      "title": "${kind}-${id} 参考样例（ESC 关闭）",
+                                      "body": [
+                                        {
+                                          "type": "websocketMarkdownViewer",
+                                          "url": "/ai/chat/example/field",
+                                          "params": {
+                                            "kind": "${kind}",
+                                            "group": "${group}",
+                                            "version": "${version}",
+                                            "field": "${full_id}"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "visibleOn": "${id}"
+                                  },
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>类型：</strong> <span class='label label-primary'>${type}</span>",
+                                    "visibleOn": "${type}"
+                                  },
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>描述：</strong> ${description}",
+                                    "visibleOn": "${description}"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "service",
+                                "id": "detail",
+                                "api": "post:/k8s/doc/detail",
+                                "body": [
+                                  {
+                                    "type": "divider",
+                                    "title": "描述翻译",
+                                    "titlePosition": "center",
+                                    "visibleOn": "${translate}"
+                                  },
+                                  {
+                                    "type": "markdown",
+                                    "value": "${translate|raw}",
+                                    "options": {
+                                      "linkify": true,
+                                      "html": true,
+                                      "breaks": true
+                                    },
+                                    "visibleOn": "${translate}"
+                                  },
+                                  {
+                                    "type": "container",
+                                    "body": [
+                                      {
+                                        "type": "tpl",
+                                        "tpl": "<div style='height:80vh'>&nbsp</div>"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "actions": []
+              }
+            }
+          ],
+          "toggled": true
+        },
+        {
+          "name": "metadata.name",
+          "label": "名称",
+          "type": "text",
+          "width": "180px",
+          "sortable": true,
+          "searchable": {
+            "type": "input-text",
+            "name": "metadata.name",
+            "clearable": true,
+            "label": "名称",
+            "placeholder": "输入名称"
+          }
+        },
+        {
+          "name": "metadata.labels",
+          "label": "标签",
+          "type": "tpl",
+          "tpl": "${metadata.labels ? '<i class=\"fa fa-tags text-primary\"></i>' : '<i class=\"fa fa-tags text-secondary\"></i>'}",
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "actionType": "dialog",
+                  "dialog": {
+                    "title": "${metadata.name} 标签 (ESC 关闭)",
+                    "name": "dialog_labels",
+                    "size": "lg",
+                    "closeOnEsc": true,
+                    "closeOnOutside": true,
+                    "body": [
+                      {
+                        "type": "form",
+                        "mode": "horizontal",
+                        "labelWidth": 0,
+                        "api": "post:/k8s/$kind/group/$group/version/$version/update_labels/ns/$metadata.namespace/name/$metadata.name",
+                        "body": [
+                          {
+                            "type": "input-kv",
+                            "name": "labels",
+                            "draggable": false,
+                            "value": "${metadata.labels}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "style": {
+            "cursor": "pointer"
+          }
+        },
+        {
+          "name": "metadata.annotations",
+          "label": "注解",
+          "type": "tpl",
+          "tpl": "${metadata.annotations|filterAnnotations|showAnnotationIcon|isTrue:'<i class=\"fa fa-note-sticky text-primary\"></i>':'<i class=\"fa fa-note-sticky text-secondary\"></i>'}",
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "actionType": "dialog",
+                  "dialog": {
+                    "title": "${metadata.name} 注解 (ESC 关闭)",
+                    "name": "dialog_annotations",
+                    "body": [
+                      {
+                        "type": "form",
+                        "mode": "horizontal",
+                        "labelWidth": 0,
+                        "api": "post:/k8s/$kind/group/$group/version/$version/update_annotations/ns/$metadata.namespace/name/$metadata.name",
+                        "initApi": "get:/k8s/$kind/group/$group/version/$version/annotations/ns/$metadata.namespace/name/$metadata.name",
+                        "body": [
+                          {
+                            "type": "input-kv",
+                            "name": "annotations",
+                            "draggable": false,
+                            "value": "${annotations}"
+                          }
+                        ]
+                      }
+                    ],
+                    "size": "lg",
+                    "closeOnEsc": true,
+                    "closeOnOutside": true
+                  }
+                }
+              ]
+            }
+          },
+          "style": {
+            "cursor": "pointer"
+          }
+        },
+        {
+          "name": "status.conditions",
+          "label": "条件",
+          "type": "k8sTextConditions"
+        },
+        {
+          "name": "metadata.creationTimestamp",
+          "label": "存在时长",
+          "type": "k8sAge"
+        }
+      ]
+    }
+  ]
+}

--- a/ui/public/pages/openkruise/persistentpodstate.json
+++ b/ui/public/pages/openkruise/persistentpodstate.json
@@ -1,0 +1,780 @@
+{
+  "type": "page",
+  "data": {
+    "ns": "${ls:selectedNs||'default'}",
+    "kind": "PersistentPodState",
+    "group": "apps.kruise.io",
+    "version": "v1alpha1"
+  },
+  "body": [
+    {
+      "type": "container",
+      "className": "floating-toolbar",
+      "body": [
+        {
+          "type": "tpl",
+          "tpl": "${kind}",
+          "className": "mr-2"
+        },
+        {
+          "type": "button",
+          "label": "属性文档",
+          "level": "link",
+          "icon": "fas fa-book-open text-primary",
+          "actionType": "drawer",
+          "drawer": {
+            "overlay": false,
+            "closeOnEsc": true,
+            "closeOnOutside": true,
+            "size": "lg",
+            "title": "${kind} 属性文档（ESC 关闭）",
+            "body": [
+              {
+                "type": "page",
+                "asideResizor": true,
+                "asideSticky": false,
+                "aside": [
+                  {
+                    "type": "input-tree",
+                    "name": "tree",
+                    "initiallyOpen": false,
+                    "unfoldedLevel": 1,
+                    "searchable": true,
+                    "showOutline": true,
+                    "showIcon": true,
+                    "searchConfig": {
+                      "sticky": true
+                    },
+                    "heightAuto": true,
+                    "inputClassName": "no-border no-padder mt-1",
+                    "source": "get:/k8s/doc/kind/$kind/group/$group/version/$version",
+                    "onEvent": {
+                      "change": {
+                        "actions": [
+                          {
+                            "componentId": "basic",
+                            "actionType": "reload",
+                            "data": {
+                              "description": "${event.data.item.description}",
+                              "id": "${event.data.item.id}",
+                              "full_id": "${event.data.item.full_id}",
+                              "type": "${event.data.item.type}"
+                            }
+                          },
+                          {
+                            "componentId": "detail",
+                            "actionType": "reload",
+                            "data": {
+                              "description": "${event.data.item.description}",
+                              "id": "${event.data.item.id}",
+                              "full_id": "${event.data.item.full_id}",
+                              "type": "${event.data.item.type}"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "body": [
+                  {
+                    "type": "service",
+                    "id": "basic",
+                    "body": [
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>属性：</strong> ${id}",
+                        "visibleOn": "${id}"
+                      },
+                      {
+                        "type": "button",
+                        "label": "示例",
+                        "level": "link",
+                        "icon": "fas fa-lightbulb text-warning",
+                        "actionType": "drawer",
+                        "drawer": {
+                          "overlay": false,
+                          "closeOnEsc": true,
+                          "closeOnOutside": true,
+                          "size": "lg",
+                          "title": "${kind}-${id} 参考样例（ESC 关闭）",
+                          "body": [
+                            {
+                              "type": "websocketMarkdownViewer",
+                              "url": "/ai/chat/example/field",
+                              "params": {
+                                "kind": "${kind}",
+                                "group": "${group}",
+                                "version": "${version}",
+                                "field": "${full_id}"
+                              }
+                            }
+                          ]
+                        },
+                        "visibleOn": "${id}"
+                      },
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>类型：</strong> <span class='label label-primary'>${type}</span>",
+                        "visibleOn": "${type}"
+                      },
+                      {
+                        "type": "tpl",
+                        "tpl": "<br><strong>描述：</strong> ${description}",
+                        "visibleOn": "${description}"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "service",
+                    "id": "detail",
+                    "api": "post:/k8s/doc/detail",
+                    "body": [
+                      {
+                        "type": "divider",
+                        "title": "描述翻译",
+                        "titlePosition": "center",
+                        "visibleOn": "${translate}"
+                      },
+                      {
+                        "type": "markdown",
+                        "value": "${translate|raw}",
+                        "options": {
+                          "linkify": true,
+                          "html": true,
+                          "breaks": true
+                        },
+                        "visibleOn": "${translate}"
+                      },
+                      {
+                        "type": "container",
+                        "body": [
+                          {
+                            "type": "tpl",
+                            "tpl": "<div style='height:80vh'>&nbsp</div>"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "button",
+          "label": "指南",
+          "level": "link",
+          "icon": "fas fa-lightbulb text-primary",
+          "actionType": "drawer",
+          "drawer": {
+            "overlay": false,
+            "closeOnEsc": true,
+            "closeOnOutside": true,
+            "size": "lg",
+            "title": "${kind} 参考样例（ESC 关闭）",
+            "body": [
+              {
+                "type": "websocketMarkdownViewer",
+                "url": "/ai/chat/example",
+                "params": {
+                  "kind": "${kind}",
+                  "group": "${group}",
+                  "version": "${version}"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "label": "创建",
+          "icon": "fas fa-dharmachakra text-primary",
+          "type": "button",
+          "level": "link",
+          "actionType": "url",
+          "blank": true,
+          "url": "/#/apply/apply?kind=${kind}"
+        }
+      ]
+    },
+    {
+      "type": "container",
+      "className": "floating-toolbar-right",
+      "body": [
+        {
+          "type": "wrapper",
+          "body": [
+            {
+              "type": "form",
+              "mode": "inline",
+              "wrapWithPanel": false,
+              "body": [
+                {
+                  "label": "命名空间",
+                  "type": "select",
+                  "multiple": true,
+                  "maxTagCount": 1,
+                  "name": "ns",
+                  "id": "ns",
+                  "searchable": true,
+                  "checkAll": true,
+                  "source": "/k8s/ns/option_list",
+                  "value": "${ls:selectedNs||'default'}",
+                  "onEvent": {
+                    "change": {
+                      "actions": [
+                        {
+                          "actionType": "reload",
+                          "componentId": "detailCRUD",
+                          "data": {
+                            "ns": "${ns}"
+                          }
+                        },
+                        {
+                          "actionType": "custom",
+                          "script": "localStorage.setItem('selectedNs', event.data.ns)"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "label": "集群",
+                  "type": "select",
+                  "multiple": false,
+                  "name": "cluster",
+                  "id": "cluster",
+                  "searchable": true,
+                  "source": "/params/cluster/option_list",
+                  "value": "${ls:cluster}",
+                  "onEvent": {
+                    "change": {
+                      "actions": [
+                        {
+                          "actionType": "custom",
+                          "script": "localStorage.setItem('cluster', event.data.value)"
+                        },
+                        {
+                          "actionType": "custom",
+                          "script": "window.location.reload();"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "crud",
+      "id": "detailCRUD",
+      "name": "detailCRUD",
+      "autoFillHeight": true,
+      "autoGenerateFilter": {
+        "columnsNum": 4,
+        "showBtnToolbar": false
+      },
+      "headerToolbar": [
+        {
+          "type": "columns-toggler",
+          "align": "right",
+          "draggable": true,
+          "icon": "fas fa-cog",
+          "overlay": true,
+          "footerBtnSize": "sm"
+        },
+        {
+          "type": "tpl",
+          "tpl": "共${count}条",
+          "align": "right",
+          "visibleOn": "${count}"
+        },
+        {
+          "type": "columns-toggler",
+          "align": "left"
+        },
+        "reload",
+        "bulkActions"
+      ],
+      "loadDataOnce": false,
+      "syncLocation": false,
+      "initFetch": true,
+      "perPage": 10,
+      "bulkActions": [
+        {
+          "label": "批量删除",
+          "actionType": "ajax",
+          "confirmText": "确定要批量删除?",
+          "api": {
+            "url": "/k8s/$kind/group/$group/version/$version/batch/remove",
+            "method": "post",
+            "data": {
+              "name_list": "${selectedItems | pick:metadata.name }",
+              "ns_list": "${selectedItems | pick:metadata.namespace }"
+            }
+          }
+        },
+        {
+          "label": "强制删除",
+          "actionType": "ajax",
+          "confirmText": "确定要批量强制删除?",
+          "api": {
+            "url": "/k8s/$kind/group/$group/version/$version/force_remove",
+            "method": "post",
+            "data": {
+              "name_list": "${selectedItems | pick:metadata.name }",
+              "ns_list": "${selectedItems | pick:metadata.namespace }"
+            }
+          }
+        }
+      ],
+      "footerToolbar": [
+        {
+          "type": "pagination",
+          "align": "right"
+        },
+        {
+          "type": "statistics",
+          "align": "right"
+        },
+        {
+          "type": "switch-per-page",
+          "align": "right"
+        }
+      ],
+      "api": "post:/k8s/$kind/group/$group/version/$version/list/ns/${ns}",
+      "columns": [
+        {
+          "type": "operation",
+          "label": "操作",
+          "width": 120,
+          "buttons": [
+            {
+              "type": "button",
+              "icon": "fas fa-eye text-primary",
+              "actionType": "drawer",
+              "tooltip": "资源描述",
+              "drawer": {
+                "closeOnEsc": true,
+                "closeOnOutside": true,
+                "size": "xl",
+                "title": "Describe: ${metadata.name}  (ESC 关闭)",
+                "body": [
+                  {
+                    "type": "service",
+                    "api": "post:/k8s/$kind/group/$group/version/$version/describe/ns/$metadata.namespace/name/$metadata.name",
+                    "body": [
+                      {
+                        "type": "button",
+                        "label": "AI解读",
+                        "icon": "fas fa-brain text-primary",
+                        "actionType": "drawer",
+                        "drawer": {
+                          "closeOnEsc": true,
+                          "closeOnOutside": true,
+                          "size": "xl",
+                          "title": "AI解读  (ESC 关闭)",
+                          "body": [
+                            {
+                              "type": "websocketMarkdownViewer",
+                              "url": "/ai/chat/describe",
+                              "params": {
+                                "kind": "${kind}",
+                                "group": "${group}",
+                                "version": "${version}",
+                                "name": "${metadata.name}",
+                                "namespace": "${metadata.namespace}"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "highlightHtml",
+                        "keywords": [
+                          "Error",
+                          "Warning"
+                        ],
+                        "html": "${result}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "button",
+              "icon": "fa fa-edit text-primary",
+              "tooltip": "Yaml编辑",
+              "actionType": "drawer",
+              "drawer": {
+                "closeOnEsc": true,
+                "closeOnOutside": true,
+                "size": "lg",
+                "title": "Yaml管理",
+                "body": [
+                  {
+                    "type": "tabs",
+                    "tabsMode": "tiled",
+                    "tabs": [
+                      {
+                        "title": "查看编辑",
+                        "body": [
+                          {
+                            "type": "service",
+                            "api": "get:/k8s/$kind/group/$group/version/$version/ns/$metadata.namespace/name/$metadata.name",
+                            "body": [
+                              {
+                                "type": "mEditor",
+                                "text": "${yaml}",
+                                "componentId": "yaml",
+                                "saveApi": "/k8s/${kind}/group/${group}/version/${version}/update/ns/${metadata.namespace}/name/${metadata.name}",
+                                "options": {
+                                  "language": "yaml",
+                                  "wordWrap": "on",
+                                  "scrollbar": {
+                                    "vertical": "auto"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "title": "文档",
+                        "body": [
+                          {
+                            "type": "page",
+                            "asideResizor": true,
+                            "asideSticky": false,
+                            "aside": [
+                              {
+                                "type": "input-tree",
+                                "name": "tree",
+                                "initiallyOpen": false,
+                                "unfoldedLevel": 1,
+                                "searchable": true,
+                                "showOutline": true,
+                                "showIcon": true,
+                                "searchConfig": {
+                                  "sticky": true
+                                },
+                                "heightAuto": true,
+                                "inputClassName": "no-border no-padder mt-1",
+                                "source": "get:/k8s/doc/gvk/${apiVersion|base64Encode}/$kind",
+                                "onEvent": {
+                                  "change": {
+                                    "actions": [
+                                      {
+                                        "componentId": "basic",
+                                        "actionType": "reload",
+                                        "data": {
+                                          "description": "${event.data.item.description}",
+                                          "id": "${event.data.item.id}",
+                                          "full_id": "${event.data.item.full_id}",
+                                          "type": "${event.data.item.type}"
+                                        }
+                                      },
+                                      {
+                                        "componentId": "detail",
+                                        "actionType": "reload",
+                                        "data": {
+                                          "description": "${event.data.item.description}",
+                                          "id": "${event.data.item.id}",
+                                          "full_id": "${event.data.item.full_id}",
+                                          "type": "${event.data.item.type}"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "body": [
+                              {
+                                "type": "service",
+                                "id": "basic",
+                                "body": [
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>属性：</strong> ${id}",
+                                    "visibleOn": "${id}"
+                                  },
+                                  {
+                                    "type": "button",
+                                    "label": "示例",
+                                    "level": "link",
+                                    "icon": "fas fa-lightbulb text-warning",
+                                    "actionType": "drawer",
+                                    "drawer": {
+                                      "overlay": false,
+                                      "closeOnEsc": true,
+                                      "closeOnOutside": true,
+                                      "size": "lg",
+                                      "title": "${kind}-${id} 参考样例（ESC 关闭）",
+                                      "body": [
+                                        {
+                                          "type": "websocketMarkdownViewer",
+                                          "url": "/ai/chat/example/field",
+                                          "params": {
+                                            "kind": "${kind}",
+                                            "group": "${group}",
+                                            "version": "${version}",
+                                            "field": "${full_id}"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "visibleOn": "${id}"
+                                  },
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>类型：</strong> <span class='label label-primary'>${type}</span>",
+                                    "visibleOn": "${type}"
+                                  },
+                                  {
+                                    "type": "tpl",
+                                    "tpl": "<br><strong>描述：</strong> ${description}",
+                                    "visibleOn": "${description}"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "service",
+                                "id": "detail",
+                                "api": "post:/k8s/doc/detail",
+                                "body": [
+                                  {
+                                    "type": "divider",
+                                    "title": "描述翻译",
+                                    "titlePosition": "center",
+                                    "visibleOn": "${translate}"
+                                  },
+                                  {
+                                    "type": "markdown",
+                                    "value": "${translate|raw}",
+                                    "options": {
+                                      "linkify": true,
+                                      "html": true,
+                                      "breaks": true
+                                    },
+                                    "visibleOn": "${translate}"
+                                  },
+                                  {
+                                    "type": "container",
+                                    "body": [
+                                      {
+                                        "type": "tpl",
+                                        "tpl": "<div style='height:80vh'>&nbsp</div>"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "actions": []
+              }
+            }
+          ],
+          "toggled": true
+        },
+        {
+          "name": "metadata.namespace",
+          "label": "命名空间",
+          "type": "text",
+          "sortable": true
+        },
+        {
+          "name": "metadata.name",
+          "label": "名称",
+          "type": "text",
+          "width": "180px",
+          "sortable": true,
+          "searchable": {
+            "type": "input-text",
+            "name": "metadata.name",
+            "clearable": true,
+            "label": "名称",
+            "placeholder": "输入名称"
+          }
+        },
+        {
+          "label": "目标",
+          "width": "150px",
+          "type": "tpl",
+          "tpl": "[<%= data.spec.targetRef.kind %>]<%= data.spec.targetRef.name %>"
+        },
+        {
+          "name": "spec.requiredPersistentTopology.nodeTopologyKeys",
+          "label": "节点选择器",
+          "type": "tpl",
+          "tpl": "<i class='fa fa-sitemap text-primary'></i>",
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "actionType": "dialog",
+                  "dialog": {
+                    "title": "${metadata.name} 节点拓扑键 (ESC 关闭)",
+                    "name": "dialog_annotations",
+                    "body": [
+                      {
+                        "type": "tpl",
+                        "tpl": "<strong>强制分布节点标签</strong>",
+                        "visibleOn": "Array.isArray(spec.requiredPersistentTopology?.nodeTopologyKeys) && spec.requiredPersistentTopology.nodeTopologyKeys.length > 0"
+                      },
+                      {
+                        "type": "json",
+                        "label": "节点标签",
+                        "source": "${spec.requiredPersistentTopology.nodeTopologyKeys}",
+                        "levelExpand": 1,
+                        "visibleOn": "Array.isArray(spec.requiredPersistentTopology?.nodeTopologyKeys) && spec.requiredPersistentTopology.nodeTopologyKeys.length > 0"
+                      },
+                      {
+                        "type": "container",
+                        "body": [
+                          {
+                            "type": "tpl",
+                            "tpl": "<strong>优先分布节点标签</strong>",
+                            "visibleOn": "Array.isArray(spec.preferredPersistentTopology) && spec.preferredPersistentTopology.length > 0"
+                          },
+                          {
+                            "type": "each",
+                            "name": "spec.preferredPersistentTopology",
+                            "visibleOn": "Array.isArray(spec.preferredPersistentTopology) && spec.preferredPersistentTopology.length > 0",
+                            "items": {
+                              "type": "panel",
+                              "title": "权重：${weight}",
+                              "body": [
+                                {
+                                  "type": "json",
+                                  "label": "节点标签",
+                                  "source": "${preference.nodeTopologyKeys}",
+                                  "levelExpand": 1
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "size": "lg",
+                    "closeOnEsc": true,
+                    "closeOnOutside": true
+                  }
+                }
+              ]
+            }
+          },
+          "style": {
+            "cursor": "pointer"
+          }
+        },
+        {
+          "name": "metadata.labels",
+          "label": "标签",
+          "type": "tpl",
+          "tpl": "${metadata.labels ? '<i class=\"fa fa-tags text-primary\"></i>' : '<i class=\"fa fa-tags text-secondary\"></i>'}",
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "actionType": "dialog",
+                  "dialog": {
+                    "title": "${metadata.name} 标签 (ESC 关闭)",
+                    "name": "dialog_labels",
+                    "size": "lg",
+                    "closeOnEsc": true,
+                    "closeOnOutside": true,
+                    "body": [
+                      {
+                        "type": "form",
+                        "mode": "horizontal",
+                        "labelWidth": 0,
+                        "api": "post:/k8s/$kind/group/$group/version/$version/update_labels/ns/$metadata.namespace/name/$metadata.name",
+                        "body": [
+                          {
+                            "type": "input-kv",
+                            "name": "labels",
+                            "draggable": false,
+                            "value": "${metadata.labels}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "style": {
+            "cursor": "pointer"
+          }
+        },
+        {
+          "name": "metadata.annotations",
+          "label": "注解",
+          "type": "tpl",
+          "tpl": "${metadata.annotations|filterAnnotations|showAnnotationIcon|isTrue:'<i class=\"fa fa-note-sticky text-primary\"></i>':'<i class=\"fa fa-note-sticky text-secondary\"></i>'}",
+          "onEvent": {
+            "click": {
+              "actions": [
+                {
+                  "actionType": "dialog",
+                  "dialog": {
+                    "title": "${metadata.name} 注解 (ESC 关闭)",
+                    "name": "dialog_annotations",
+                    "body": [
+                      {
+                        "type": "form",
+                        "mode": "horizontal",
+                        "labelWidth": 0,
+                        "api": "post:/k8s/$kind/group/$group/version/$version/update_annotations/ns/$metadata.namespace/name/$metadata.name",
+                        "initApi": "get:/k8s/$kind/group/$group/version/$version/annotations/ns/$metadata.namespace/name/$metadata.name",
+                        "body": [
+                          {
+                            "type": "input-kv",
+                            "name": "annotations",
+                            "draggable": false,
+                            "value": "${annotations}"
+                          }
+                        ]
+                      }
+                    ],
+                    "size": "lg",
+                    "closeOnEsc": true,
+                    "closeOnOutside": true
+                  }
+                }
+              ]
+            }
+          },
+          "style": {
+            "cursor": "pointer"
+          }
+        },
+        {
+          "name": "status.conditions",
+          "label": "条件",
+          "type": "k8sTextConditions"
+        },
+        {
+          "name": "metadata.creationTimestamp",
+          "label": "存在时长",
+          "type": "k8sAge"
+        }
+      ]
+    }
+  ]
+}

--- a/ui/public/pages/openkruise/persistentpodstate.json
+++ b/ui/public/pages/openkruise/persistentpodstate.json
@@ -765,11 +765,6 @@
           }
         },
         {
-          "name": "status.conditions",
-          "label": "条件",
-          "type": "k8sTextConditions"
-        },
-        {
           "name": "metadata.creationTimestamp",
           "label": "存在时长",
           "type": "k8sAge"

--- a/ui/public/pages/openkruise/podprobemarker.json
+++ b/ui/public/pages/openkruise/podprobemarker.json
@@ -2,7 +2,7 @@
   "type": "page",
   "data": {
     "ns": "${ls:selectedNs||'default'}",
-    "kind": "ImagePullJob",
+    "kind": "PodProbeMarker",
     "group": "apps.kruise.io",
     "version": "v1alpha1"
   },
@@ -610,14 +610,8 @@
           }
         },
         {
-          "name": "spec.image",
-          "label": "镜像",
-          "type": "text",
-          "sortable": true
-        },
-        {
-          "name": "spec.selector",
-          "label": "节点选择器",
+          "name": "spec.selector.matchLabels",
+          "label": "POD选择器",
           "type": "tpl",
           "tpl": "<i class='fa fa-sitemap text-primary'></i>",
           "onEvent": {
@@ -626,47 +620,14 @@
                 {
                   "actionType": "dialog",
                   "dialog": {
-                    "title": "${metadata.name} 节点选择器 (ESC 关闭)",
+                    "title": "${metadata.name} POD选择器 (ESC 关闭)",
                     "name": "dialog_annotations",
                     "body": [
                       {
-                        "type": "tpl",
-                        "tpl": "<strong>节点名称</strong>",
-                        "visibleOn": "${spec.selector.names}"
-                      },
-                      {
-                        "type": "each",
-                        "label": "节点名称",
-                        "name": "spec.selector.names",
-                        "items": {
-                          "type": "tpl",
-                          "tpl": "${item}<br>"
-                        },
-                        "visibleOn": "${spec.selector.names}"
-                      },
-                      {
-                        "type": "tpl",
-                        "tpl": "<strong>节点标签</strong>",
-                        "visibleOn": "${spec.selector.matchLabels}"
-                      },
-                      {
                         "type": "json",
-                        "label": "节点标签",
+                        "label": "POD选择器",
                         "source": "${spec.selector.matchLabels}",
-                        "levelExpand": 1,
-                        "visibleOn": "${spec.selector.matchLabels}"
-                      },
-                      {
-                        "type": "tpl",
-                        "tpl": "<strong>Pod所在节点</strong>",
-                        "visibleOn": "${spec.podSelector.matchLabels}"
-                      },
-                      {
-                        "type": "json",
-                        "label": "Pod所在节点",
-                        "source": "${spec.podSelector.matchLabels}",
-                        "levelExpand": 1,
-                        "visibleOn": "${spec.podSelector.matchLabels}"
+                        "levelExpand": 1
                       }
                     ],
                     "size": "lg",
@@ -682,8 +643,14 @@
           }
         },
         {
-          "name": "spec.parallelism",
-          "label": "并发数"
+          "name": "spec.probes",
+          "label": "探测容器<br><span class='text-gray-500 text-xs'>容器名称=>探测字段(规则数量)</span>",
+          "width": "150px",
+          "type": "each",
+          "items": {
+            "type": "tpl",
+            "tpl": "<div style='margin-bottom: 10px;'><strong class='text-green-500 font-black'>${containerName}</strong>=>${podConditionType}(${markerPolicy|count})</div>"
+          }
         },
         {
           "name": "metadata.labels",
@@ -767,12 +734,6 @@
           "style": {
             "cursor": "pointer"
           }
-        },
-        {
-          "name": "状态",
-          "label": "状态",
-          "type": "tpl",
-          "tpl": "<span style='margin-right: 2px;'><strong>运:</strong>${status.active}</span><span style='margin-right: 2px;'><strong>完:</strong>${status.succeeded}</span><span style='margin-right: 2px;'><strong>败:</strong>${status.failed}</span><span><strong>总:</strong>${status.desired}</span><br><span>${status.message}</span>"
         },
         {
           "name": "metadata.creationTimestamp",

--- a/ui/src/components/Sidebar/menu.tsx
+++ b/ui/src/components/Sidebar/menu.tsx
@@ -264,6 +264,13 @@ const items: () => MenuItem[] = () => {
                         key: "PodUnavailableBudget",
                         onClick: () => onMenuClick('/openkruise/PodUnavailableBudget')
                     },
+                    {
+                        label: "资源分发",
+                        title: "资源分发",
+                        icon: <i className="fa-solid fa-share-nodes"></i>,
+                        key: "ResourceDistribution",
+                        onClick: () => onMenuClick('/openkruise/ResourceDistribution')
+                    },
 
                 ],
             },

--- a/ui/src/components/Sidebar/menu.tsx
+++ b/ui/src/components/Sidebar/menu.tsx
@@ -244,6 +244,13 @@ const items: () => MenuItem[] = () => {
                         key: "imagepulljob",
                         onClick: () => onMenuClick('/openkruise/imagepulljob')
                     },
+                    {
+                        label: "持久化状态",
+                        title: "持久化状态",
+                        icon: <i className="fa-solid fa-cloud-arrow-down"></i>,
+                        key: "persistentpodstate",
+                        onClick: () => onMenuClick('/openkruise/persistentpodstate')
+                    },
                 ],
             },
         ] : []),

--- a/ui/src/components/Sidebar/menu.tsx
+++ b/ui/src/components/Sidebar/menu.tsx
@@ -247,9 +247,15 @@ const items: () => MenuItem[] = () => {
                     {
                         label: "持久化状态",
                         title: "持久化状态",
-                        icon: <i className="fa-solid fa-cloud-arrow-down"></i>,
+                        icon: <i className="fa-solid fa-database"></i>,
                         key: "persistentpodstate",
                         onClick: () => onMenuClick('/openkruise/persistentpodstate')
+                    }, {
+                        label: "Pod探测标记",
+                        title: "Pod探测标记",
+                        icon: <i className="fa-solid fa-magnifying-glass"></i>,
+                        key: "podprobemarker",
+                        onClick: () => onMenuClick('/openkruise/podprobemarker')
                     },
                 ],
             },

--- a/ui/src/components/Sidebar/menu.tsx
+++ b/ui/src/components/Sidebar/menu.tsx
@@ -257,6 +257,14 @@ const items: () => MenuItem[] = () => {
                         key: "podprobemarker",
                         onClick: () => onMenuClick('/openkruise/podprobemarker')
                     },
+                    {
+                        label: "Pod不可用预算",
+                        title: "Pod不可用预算",
+                        icon: <i className="fa-solid fa-circle-exclamation"></i>,
+                        key: "PodUnavailableBudget",
+                        onClick: () => onMenuClick('/openkruise/PodUnavailableBudget')
+                    },
+
                 ],
             },
         ] : []),


### PR DESCRIPTION
支持对如下OpenKruise资源管理：
advancedcronjobs.apps.kruise.io                
broadcastjobs.apps.kruise.io                   
clonesets.apps.kruise.io                       
containerrecreaterequests.apps.kruise.io       
daemonsets.apps.kruise.io                      
imagelistpulljobs.apps.kruise.io               
imagepulljobs.apps.kruise.io                   
nodeimages.apps.kruise.io                      
nodepodprobes.apps.kruise.io                   
persistentpodstates.apps.kruise.io             
podprobemarkers.apps.kruise.io                 
podunavailablebudgets.policy.kruise.io         
resourcedistributions.apps.kruise.io           
sidecarsets.apps.kruise.io                     
statefulsets.apps.kruise.io                    
uniteddeployments.apps.kruise.io               
workloadspreads.apps.kruise.io                 