### PR TITLE
fix(集群配置): 将NotAfter字段改为指针类型并优化缓存获取逻辑

### DIFF
--- a/pkg/service/clusters.go
+++ b/pkg/service/clusters.go
@@ -61,7 +61,7 @@ type ClusterConfig struct {
 	Source                  ClusterConfigSource            `json:"source,omitempty"`                 // 配置文件来源
 	K8sGPTProblemsCount     int                            `json:"k8s_gpt_problems_count,omitempty"` // k8sGPT 扫描结果
 	K8sGPTProblemsResult    *analysis.ResultWithStatus     `json:"k8s_gpt_problems,omitempty"`       // k8sGPT 扫描结果
-	NotAfter                time.Time                      `json:"not_after,omitempty"`
+	NotAfter                *time.Time                     `json:"not_after,omitempty"`
 }
 type ClusterConfigSource string
 


### PR DESCRIPTION
将ClusterConfig中的NotAfter字段从time.Time改为*time.Time以更好处理空值情况 优化ClusterTableList中的缓存获取逻辑，避免重复获取已连接集群配置