### PR TITLE
refactor(集群): 将过期时间相关命名改为证书有效期

### DIFF
--- a/pkg/controller/param/cluster.go
+++ b/pkg/controller/param/cluster.go
@@ -80,7 +80,7 @@ func ClusterTableList(c *gin.Context) {
 		}) {
 			cacheKey := fmt.Sprintf("%s/kubeconfig/not_after", cluster.ClusterID)
 			if notAfter, err := utils.GetOrSetCache(kom.Cluster(cluster.ClusterID).ClusterCache(), cacheKey, 24*time.Hour, func() (time.Time, error) {
-				return cluster.GetNotAfter(), nil
+				return cluster.GetCertificateExpiry(), nil
 			}); err == nil {
 				cluster.NotAfter = &notAfter
 			}

--- a/pkg/service/clusters.go
+++ b/pkg/service/clusters.go
@@ -154,8 +154,8 @@ func (c *clusterService) GetClusterByID(id string) *ClusterConfig {
 	return nil
 }
 
-// GetNotAfter 获取集群配置过期时间
-func (c *ClusterConfig) GetNotAfter() time.Time {
+// GetCertificateExpiry 获取集群证书的过期时间
+func (c *ClusterConfig) GetCertificateExpiry() time.Time {
 	config, err := clientcmd.Load(c.kubeConfig)
 	if err != nil {
 		klog.V(8).Infof("设置NotAfter, 解析文件[%s]失败: %v", c.ClusterID, err)
@@ -171,7 +171,7 @@ func (c *ClusterConfig) GetNotAfter() time.Time {
 		klog.V(8).Infof("设置NotAfter,  [%s]解析证书:%s 失败: %v", c.ClusterID, authInfo.ClientCertificateData, err)
 		return time.Time{}
 	}
-	return cert.NotAfter
+	return cert.NotAfter.Local()
 }
 
 // IsConnected 判断集群是否连接

--- a/ui/public/pages/admin/cluster/cluster_all.json
+++ b/ui/public/pages/admin/cluster/cluster_all.json
@@ -926,7 +926,7 @@
         },
         {
           "name": "not_after",
-          "label": "集群配置过期时间",
+          "label": "证书有效期",
           "type": "text",
           "sortable": true
         }

--- a/ui/public/pages/user/cluster/cluster_user.json
+++ b/ui/public/pages/user/cluster/cluster_user.json
@@ -188,7 +188,7 @@
         },
         {
           "name": "not_after",
-          "label": "集群配置过期时间",
+          "label": "证书有效期",
           "type": "text",
           "sortable": true
         }


### PR DESCRIPTION
将字段名、方法名及显示标签从"集群配置过期时间"统一改为"证书有效期"，更准确反映实际含义