### PR TITLE
build: 禁用helm安装时的校验检查

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 ADD reload.sh /app/reload.sh
 RUN chmod +x /app/reload.sh
 
-RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+RUN export VERIFY_CHECKSUM=false&&curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 RUN helm version
 
 

--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -32,7 +32,7 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 ADD reload.sh /app/reload.sh
 RUN chmod +x /app/reload.sh
 
-RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+RUN export VERIFY_CHECKSUM=false&&curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 RUN helm version
 
 #k8m Server


### PR DESCRIPTION
为了加快构建速度并避免潜在的校验失败，在安装helm时禁用校验检查