### PR TITLE
chore(docker): 在镜像中添加 aws-cli 依赖

### DIFF
--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -27,7 +27,7 @@ ENV TZ=Asia/Shanghai
 COPY --from=golang-builder /app/k8m .
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
-    && apk upgrade && apk add --no-cache curl bash inotify-tools alpine-conf busybox-extras tzdata   tar gzip\
+    && apk upgrade && apk add --no-cache curl bash inotify-tools alpine-conf busybox-extras tzdata  aws-cli tar gzip\
     && apk del alpine-conf && rm -rf /var/cache/* && chmod +x k8m
 ADD reload.sh /app/reload.sh
 RUN chmod +x /app/reload.sh


### PR DESCRIPTION
- 修改 apk 安装命令，新增 aws-cli 包
- 优化镜像构建过程，保持其他依赖不变
- 确保所有必需工具权限正确设置