### PR TITLE
fix(admin): 修复集群显示名称中的字符串替换问题

### DIFF
--- a/pkg/controller/admin/cluster/kubeconfig.go
+++ b/pkg/controller/admin/cluster/kubeconfig.go
@@ -29,7 +29,7 @@ func (a *Controller) SaveKubeConfig(c *gin.Context) {
 		return
 	}
 
-	m.DisplayName = strings.NewReplacer("/", "-", "\\", "-", " ", "_").Replace(strings.TrimSpace(m.DisplayName))
+	m.DisplayName = strings.NewReplacer("/", "-", "\\", "-", " ").Replace(strings.TrimSpace(m.DisplayName))
 
 	if m.DisplayName == "" {
 		m.DisplayName = m.Cluster
@@ -137,7 +137,7 @@ func (a *Controller) SaveAWSEKSCluster(c *gin.Context) {
 		amis.WriteJsonError(c, err)
 		return
 	}
-	req.DisplayName = strings.NewReplacer("/", "-", "\\", "-", " ", "_").Replace(strings.TrimSpace(req.DisplayName))
+	req.DisplayName = strings.NewReplacer("/", "-", "\\", "-", " ").Replace(strings.TrimSpace(req.DisplayName))
 
 	// 如果没有提供显示名称，使用集群名称
 	if req.DisplayName == "" {


### PR DESCRIPTION
- 修正了DisplayName字符串替换逻辑，去除多余的下划线替换
- 确保显示名称中保留空格，避免替换为空格为下划线
- 统一了SaveKubeConfig和SaveAWSEKSCluster中DisplayName处理方式
- 优化了TrimSpace后的字符串替换流程逻辑