### PR TITLE
feat(webhook): 将Dingtalk消息格式从text改为markdown

### DIFF
--- a/pkg/webhook/adapters.go
+++ b/pkg/webhook/adapters.go
@@ -27,9 +27,10 @@ func (d *DingtalkAdapter) GetContentType() string {
 
 func (d *DingtalkAdapter) FormatMessage(msg, raw string, config *WebhookConfig) ([]byte, error) {
 	payload := map[string]any{
-		"msgtype": "text",
-		"text": map[string]string{
-			"content": msg,
+		"msgtype": "markdown",
+		"markdown": map[string]string{
+			"title": "通知",
+			"text":  msg,
 		},
 	}
 	return json.Marshal(payload)


### PR DESCRIPTION
支持更丰富的消息展示格式，包括标题和正文内容