### PR TITLE
fix(路由): 将MenuEditor路由路径添加集群参数前缀

### DIFF
--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -22,7 +22,7 @@ const Router = () => {
             <Route path='/k/:cluster/NodeExec' element={<NodeExec />}></Route>
             <Route path='/k/:cluster/PodExec' element={<PodExec />}></Route>
             <Route path='/k/:cluster/PodLog' element={<PodLog />}></Route>
-            <Route path='/MenuEditor' element={<MenuEditor />}></Route>
+            <Route path='/k/:cluster/MenuEditor' element={<MenuEditor />}></Route>
             <Route path='/' element={<Layout />}>
                 <Route path='/' element={<Navigate to="/user/cluster/cluster_user" />}></Route>
                 <Route path='/*' element={


### PR DESCRIPTION
确保MenuEditor页面能够正确获取集群参数，与其他集群相关页面保持一致