### PR TITLE
fix(lua): 在AI汇总失败时返回带标记的基础汇总，可区分是否因为AI总结失败

### DIFF
--- a/pkg/lua/lua_summary_ai.go
+++ b/pkg/lua/lua_summary_ai.go
@@ -121,7 +121,7 @@ func (s *ScheduleBackground) SummaryByAI(ctx context.Context, msg *SummaryMsg) (
 	aiSummary, err := s.generateAISummary(ctx, msg)
 	if err != nil {
 		klog.Errorf("AI汇总失败，返回基础汇总: %v", err)
-		return basicSummary, nil
+		return basicSummary + "[AI FBK]", nil
 	}
 
 	return aiSummary, nil


### PR DESCRIPTION
fix(lua): 在AI汇总失败时返回带标记的基础汇总，可区分是否因为AI总结失败