### PR TITLE
feat: Add MCP tool annotations for save_k8s_yaml_template

### DIFF
--- a/mcp_start.go
+++ b/mcp_start.go
@@ -131,6 +131,8 @@ func SaveYamlTemplateTool() mcp2.Tool {
 	return mcp2.NewTool(
 		"save_k8s_yaml_template",
 		mcp2.WithDescription("保存Yaml为模版"),
+		mcp2.WithTitleAnnotation("Save YAML Template"),
+		mcp2.WithDestructiveHintAnnotation(true),
 		mcp2.WithString("cluster", mcp2.Description("模板适配集群（可为空）")),
 		mcp2.WithString("yaml", mcp2.Required(), mcp2.Description("yaml模板内容，文本类型")),
 		mcp2.WithString("name", mcp2.Description("模板名称")),


### PR DESCRIPTION
## Summary
- Added `WithTitleAnnotation("Save YAML Template")` for human-readable tool title
- Added `WithDestructiveHintAnnotation(true)` since this tool creates/saves data

## Related PR
This PR complements [kom#74](https://github.com/weibaohui/kom/pull/74) which adds annotations to all 60 K8s MCP tools in the kom library.

## Why This Change
These annotations help LLM clients (like Claude) better understand tool behavior and make more informed decisions about when to use each tool. The annotations are part of the MCP specification and improve the user experience when interacting with K8s resources through AI assistants.

## Test Plan
- [ ] Verify annotations appear correctly in `tools/list` response
- [ ] Test with an LLM client to confirm improved tool understanding
- [ ] Verify no build errors with `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)