### PR TITLE
fix(plugins): 修正插件升级条件和调整启用开关显示逻辑

### DIFF
--- a/pkg/plugins/manager_api.go
+++ b/pkg/plugins/manager_api.go
@@ -92,7 +92,7 @@ func (m *Manager) ListPlugins(c *response.Context) {
 		statusStr := statusToString(m.status[name])
 		status := statusFromString(statusStr)
 		dbVer := cfgVerMap[name]
-		canUpgrade := statusStr != "discovered" && utils.CompareVersions(mod.Meta.Version, dbVer)
+		canUpgrade := statusStr != "uninstalled" && utils.CompareVersions(mod.Meta.Version, dbVer)
 		// Enabled: 已启用、运行中、已停止 状态表示插件已启用
 		enabled := status == StatusEnabled || status == StatusRunning || status == StatusStopped
 		items = append(items, PluginItemVO{

--- a/ui/public/pages/admin/plugins/list.json
+++ b/ui/public/pages/admin/plugins/list.json
@@ -353,13 +353,11 @@
                     "name": "enabled",
                     "label": "启用",
                     "width": "80px",
-                    "type": "switch",
-                    "onText": "开启",
-                    "offText": "关闭",
-                    "visibleOn": "this.status == '已安装' || this.status == '已启用' || this.status == '运行中' || this.status == '已停止' || this.status == '已禁用'",
                     "quickEdit": {
                         "mode": "inline",
                         "type": "switch",
+                        "onText": "启用",
+                        "offText": "禁用",
                         "saveImmediately": true,
                         "resetOnFailed": true
                     }


### PR DESCRIPTION
修复插件升级条件判断，将"discovered"状态改为"uninstalled"状态时才不允许升级。同时简化启用开关的显示配置，移除重复属性并统一开关文本为"启用/禁用"