### PR TITLE
feat: add auto update deployment image version in GitHub Actions

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -127,3 +127,24 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_REPONAME }}:latest
             ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_REPONAME }}:${{ steps.date.outputs.today }}
             ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_REPONAME }}:${{ env.GITHUB_REF_NAME }}
+
+      - name: Update deployment image version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          chmod +x scripts/update-deploy-image.sh
+          ./scripts/update-deploy-image.sh ${{ env.GITHUB_REF_NAME }}
+
+      - name: Commit and push updated deployment files
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add deploy/*.yaml
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update deployment image version to ${{ env.GITHUB_REF_NAME }}
+
+            Co-Authored-By: Warp <agent@warp.dev>"
+            git push origin HEAD:main
+          fi

--- a/scripts/update-deploy-image.sh
+++ b/scripts/update-deploy-image.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+# 检查参数
+if [ -z "$1" ]; then
+    echo "Usage: $0 <new-version>"
+    echo "Example: $0 v0.26.7"
+    exit 1
+fi
+
+NEW_VERSION=$1
+DEPLOY_DIR="deploy"
+
+echo "Updating image version to: $NEW_VERSION"
+
+# 更新所有 deploy/*.yaml 文件中的镜像版本
+for file in "$DEPLOY_DIR"/*.yaml; do
+    if [ -f "$file" ]; then
+        echo "Processing: $file"
+        
+        # 使用 sed 替换镜像版本
+        # 匹配 docker.io/weibh/k8m:xxx
+        sed -i.bak "s|docker.io/weibh/k8m:.*|docker.io/weibh/k8m:$NEW_VERSION|g" "$file"
+        
+        # 匹配 ghcr.io/weibaohui/k8m:xxx
+        sed -i.bak "s|ghcr.io/weibaohui/k8m:.*|ghcr.io/weibaohui/k8m:$NEW_VERSION|g" "$file"
+        
+        # 匹配 registry.cn-hangzhou.aliyuncs.com/minik8m/k8m:xxx
+        sed -i.bak "s|registry.cn-hangzhou.aliyuncs.com/minik8m/k8m:.*|registry.cn-hangzhou.aliyuncs.com/minik8m/k8m:$NEW_VERSION|g" "$file"
+        
+        # 删除备份文件
+        rm -f "$file.bak"
+        
+        echo "✓ Updated: $file"
+    fi
+done
+
+echo ""
+echo "Image version updated successfully!"
+echo "Modified files:"
+git diff --name-only "$DEPLOY_DIR/"


### PR DESCRIPTION
- 创建 scripts/update-deploy-image.sh 脚本用于自动更新 deploy/*.yaml 中的镜像版本
- 在 build-docker-image.yml 工作流中添加两个新步骤：
  1. 执行脚本更新部署文件中的镜像版本
  2. 提交并推送更新后的部署文件到 main 分支
- 仅在创建新的版本标签(v*)时触发此功能