### PR TITLE
fix: 将DecodeBase64替换为UrlSafeBase64Decode以支持URL安全编码

### DIFF
--- a/pkg/controller/admin/cluster/cluster.go
+++ b/pkg/controller/admin/cluster/cluster.go
@@ -91,7 +91,7 @@ func (a *Controller) Scan(c *response.Context) {
 // @Router /mgm/cluster/{cluster}/reconnect [post]
 func (a *Controller) Reconnect(c *response.Context) {
 	clusterBase64 := c.Param("cluster")
-	clusterID, err := utils.DecodeBase64(clusterBase64)
+	clusterID, err := utils.UrlSafeBase64Decode(clusterBase64)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -108,7 +108,7 @@ func (a *Controller) Reconnect(c *response.Context) {
 // @Router /admin/cluster/{cluster}/disconnect [post]
 func (a *Controller) Disconnect(c *response.Context) {
 	clusterBase64 := c.Param("cluster")
-	clusterID, err := utils.DecodeBase64(clusterBase64)
+	clusterID, err := utils.UrlSafeBase64Decode(clusterBase64)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return

--- a/pkg/controller/admin/user/cluster_permission.go
+++ b/pkg/controller/admin/user/cluster_permission.go
@@ -46,7 +46,7 @@ func RegisterClusterPermissionRoutes(r chi.Router) {
 func (a *AdminClusterPermission) ListClusterPermissions(c *response.Context) {
 	clusterBase64 := c.Param("cluster")
 	role := c.Param("role")
-	cluster, err := utils.DecodeBase64(clusterBase64)
+	cluster, err := utils.UrlSafeBase64Decode(clusterBase64)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -90,7 +90,7 @@ func (a *AdminClusterPermission) ListClusterPermissionsByUserName(c *response.Co
 // @Router /admin/cluster_permissions/cluster/{cluster}/list [get]
 func (a *AdminClusterPermission) ListClusterPermissionsByClusterID(c *response.Context) {
 	clusterBase64 := c.Param("cluster")
-	cluster, err := utils.DecodeBase64(clusterBase64)
+	cluster, err := utils.UrlSafeBase64Decode(clusterBase64)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -116,7 +116,7 @@ func (a *AdminClusterPermission) ListClusterPermissionsByClusterID(c *response.C
 func (a *AdminClusterPermission) ListClusterNamespaceListByClusterID(c *response.Context) {
 	ctx := amis.GetContextWithUser(c)
 	clusterBase64 := c.Param("cluster")
-	cluster, err := utils.DecodeBase64(clusterBase64)
+	cluster, err := utils.UrlSafeBase64Decode(clusterBase64)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return
@@ -157,7 +157,7 @@ func (a *AdminClusterPermission) SaveClusterPermission(c *response.Context) {
 	clusterBase64 := c.Param("cluster")
 	role := c.Param("role")
 	authorizationType := c.Param("authorization_type")
-	cluster, err := utils.DecodeBase64(clusterBase64)
+	cluster, err := utils.UrlSafeBase64Decode(clusterBase64)
 	if err != nil {
 		amis.WriteJsonError(c, err)
 		return

--- a/pkg/plugins/modules/k8sgpt/admin/controller.go
+++ b/pkg/plugins/modules/k8sgpt/admin/controller.go
@@ -85,7 +85,7 @@ func (cc *Controller) ClusterRunAnalysis(c *response.Context) {
 func (cc *Controller) ClusterRunAnalysisMgm(c *response.Context) {
 	clusterIDBase64 := c.Param("cluster")
 	if clusterIDBase64 != "" {
-		if id, err := utils.DecodeBase64(clusterIDBase64); err == nil {
+		if id, err := utils.UrlSafeBase64Decode(clusterIDBase64); err == nil {
 			if id != "" {
 				clusterIDBase64 = id
 			}
@@ -114,7 +114,7 @@ func (cc *Controller) ClusterRunAnalysisMgm(c *response.Context) {
 func (cc *Controller) GetClusterRunAnalysisResultMgm(c *response.Context) {
 	clusterIDBase64 := c.Param("cluster")
 	if clusterIDBase64 != "" {
-		if id, err := utils.DecodeBase64(clusterIDBase64); err == nil {
+		if id, err := utils.UrlSafeBase64Decode(clusterIDBase64); err == nil {
 			if id != "" {
 				clusterIDBase64 = id
 			}


### PR DESCRIPTION
修复集群相关API中base64解码问题，原函数无法正确处理URL安全编码的base64字符串（包含'-'和'_'字符），导致集群ID解码失败。统一使用UrlSafeBase64Decode确保路由参数能正确解析。