### PR TITLE
fix: 支持通过MD5值解析集群ID

### DIFF
--- a/pkg/plugins/modules/inspection/controller/schedule.go
+++ b/pkg/plugins/modules/inspection/controller/schedule.go
@@ -14,6 +14,7 @@ import (
 	"github.com/weibaohui/k8m/pkg/plugins/modules/inspection/lua"
 	"github.com/weibaohui/k8m/pkg/plugins/modules/inspection/models"
 	"github.com/weibaohui/k8m/pkg/response"
+	"github.com/weibaohui/k8m/pkg/service"
 	"gorm.io/gorm"
 )
 
@@ -124,6 +125,19 @@ func (s *AdminScheduleController) Save(c *response.Context) {
 		amis.WriteJsonError(c, err)
 		return
 	}
+
+	//将集群ID转换回原始ID
+	clusterIDs := strings.Split(m.Clusters, ",")
+	realClusterIDs := make([]string, 0)
+	for _, id := range clusterIDs {
+		real_id, err := service.ClusterService().ResolveClusterID(id)
+		if err == nil {
+			realClusterIDs = append(realClusterIDs, real_id)
+		} else {
+			realClusterIDs = append(realClusterIDs, id)
+		}
+	}
+	m.Clusters = strings.Join(realClusterIDs, ",")
 
 	// 检测cron表达式是否正确
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)

--- a/pkg/service/clusters.go
+++ b/pkg/service/clusters.go
@@ -171,6 +171,15 @@ func (c *clusterService) GetClusterByID(id string) *ClusterConfig {
 			return v
 		}
 	}
+
+	//增加MD5解析，如果ID混用为MD5，也能正常解析
+	real_id, err := c.ResolveClusterID(id)
+	if err == nil {
+		//报错说明不是md5格式的ID
+		//不报错，那就说明是MD5值的id，需要转换回原ID
+		id = real_id
+	}
+
 	// 解析selectedCluster
 	// 第一个/前面的字符是fileName。其他的都是contextName
 	// 有可能会出现多个/，如config/aws-x-x-x/demo


### PR DESCRIPTION
- 在 GetClusterByID 方法中增加 MD5 解析逻辑，当传入的 ID 为 MD5 值时，将其转换回原始 ID，确保兼容性
- 在巡检模块的 Save 方法中，将传入的集群 ID 列表进行转换，确保存储的是原始 ID