### PR TITLE
fix(inspection): install cluster inspection plugin fails with UNIQUE constraint failed

### DIFF
--- a/pkg/plugins/modules/inspection/controller/scripts.go
+++ b/pkg/plugins/modules/inspection/controller/scripts.go
@@ -120,7 +120,9 @@ func (s *AdminLuaScriptController) LuaScriptLoad(c *response.Context) {
 		amis.WriteJsonError(c, err)
 		return
 	}
-	err = dao.DB().Model(&models.InspectionLuaScript{}).CreateInBatches(models.BuiltinLuaScripts, 100).Error
+	// 先按 Name 去重，防御源数据中重名条目触发 UNIQUE 约束
+	scripts := models.DedupeBuiltinLuaScripts(models.BuiltinLuaScripts)
+	err = dao.DB().Model(&models.InspectionLuaScript{}).CreateInBatches(scripts, 100).Error
 	if err != nil {
 		klog.Errorf("插入内置巡检脚本失败: %v", err)
 		amis.WriteJsonError(c, err)

--- a/pkg/plugins/modules/inspection/models/db.go
+++ b/pkg/plugins/modules/inspection/models/db.go
@@ -6,6 +6,23 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// DedupeBuiltinLuaScripts 按 Name 去重，保留首次出现的条目。
+// 用于防御内置脚本源数据中偶然出现重名条目，避免触发 UNIQUE 约束导致插件安装/重载失败。
+// 返回新切片，不修改入参。
+func DedupeBuiltinLuaScripts(in []InspectionLuaScript) []InspectionLuaScript {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]InspectionLuaScript, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s.Name]; ok {
+			klog.V(6).Infof("跳过重名的内置巡检脚本: name=%q script_code=%q", s.Name, s.ScriptCode)
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
 // InitDB 初始化集群巡检相关数据库表（GORM 自动迁移），并写入内置脚本。
 func InitDB() error {
 	if err := dao.DB().AutoMigrate(
@@ -99,8 +116,9 @@ func AddBuiltinLuaScripts() error {
 		klog.Errorf("删除旧内置巡检脚本失败: %v", err)
 		return err
 	}
-	// 插入最新内置脚本
-	if err := db.CreateInBatches(BuiltinLuaScripts, 100).Error; err != nil {
+	// 插入最新内置脚本（先按 Name 去重，防御源数据中出现重复条目）
+	scripts := DedupeBuiltinLuaScripts(BuiltinLuaScripts)
+	if err := db.CreateInBatches(scripts, 100).Error; err != nil {
 		klog.Errorf("插入内置巡检脚本失败: %v", err)
 		return err
 	}

--- a/pkg/plugins/modules/inspection/models/db_test.go
+++ b/pkg/plugins/modules/inspection/models/db_test.go
@@ -1,0 +1,119 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/weibaohui/k8m/pkg/constants"
+)
+
+// TestBuiltinLuaScriptsHaveUniqueNames 锁定内置脚本源数据的 Name 唯一性。
+// 回归保护：历史上曾出现两条 Name 完全相同但 ScriptCode 不同的条目，导致插件安装时
+// SQLite 报 "UNIQUE constraint failed: inspection_lua_scripts.name"。
+func TestBuiltinLuaScriptsHaveUniqueNames(t *testing.T) {
+	if len(BuiltinLuaScripts) == 0 {
+		t.Fatal("BuiltinLuaScripts is empty")
+	}
+	seen := make(map[string]struct{}, len(BuiltinLuaScripts))
+	for i, s := range BuiltinLuaScripts {
+		if _, dup := seen[s.Name]; dup {
+			t.Errorf("duplicate builtin script Name at index %d: %q (script_code=%q)", i, s.Name, s.ScriptCode)
+		}
+		seen[s.Name] = struct{}{}
+		if s.ScriptType != constants.LuaScriptTypeBuiltin {
+			t.Errorf("builtin script at index %d (%q) has ScriptType=%q, want %q", i, s.Name, s.ScriptType, constants.LuaScriptTypeBuiltin)
+		}
+	}
+}
+
+// TestBuiltinLuaScriptsHaveUniqueScriptCodes 锁定内置脚本源数据的 ScriptCode 唯一性。
+func TestBuiltinLuaScriptsHaveUniqueScriptCodes(t *testing.T) {
+	seen := make(map[string]struct{}, len(BuiltinLuaScripts))
+	for i, s := range BuiltinLuaScripts {
+		if s.ScriptCode == "" {
+			t.Errorf("builtin script at index %d (%q) has empty ScriptCode", i, s.Name)
+			continue
+		}
+		if _, dup := seen[s.ScriptCode]; dup {
+			t.Errorf("duplicate builtin script ScriptCode at index %d: %q (name=%q)", i, s.ScriptCode, s.Name)
+		}
+		seen[s.ScriptCode] = struct{}{}
+	}
+}
+
+// TestDedupeBuiltinLuaScripts 验证内置脚本去重逻辑在各种重名场景下的行为。
+// 防御回归：当源数据中偶然出现重名条目时，插件安装/重载不应该因为 SQLite UNIQUE 约束失败。
+func TestDedupeBuiltinLuaScripts(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []InspectionLuaScript
+		wantNames []string
+		wantLen   int
+	}{
+		{
+			name: "no duplicates",
+			input: []InspectionLuaScript{
+				{Name: "a", ScriptCode: "code-a", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "b", ScriptCode: "code-b", ScriptType: constants.LuaScriptTypeBuiltin},
+			},
+			wantNames: []string{"a", "b"},
+			wantLen:   2,
+		},
+		{
+			name: "single duplicate keeps first occurrence",
+			input: []InspectionLuaScript{
+				{Name: "a", ScriptCode: "code-a-1", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "b", ScriptCode: "code-b", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "a", ScriptCode: "code-a-2", ScriptType: constants.LuaScriptTypeBuiltin},
+			},
+			wantNames: []string{"a", "b"},
+			wantLen:   2,
+		},
+		{
+			name: "multiple duplicates preserve order of first appearance",
+			input: []InspectionLuaScript{
+				{Name: "a", ScriptCode: "code-a-1", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "b", ScriptCode: "code-b", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "a", ScriptCode: "code-a-2", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "b", ScriptCode: "code-b-2", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "c", ScriptCode: "code-c", ScriptType: constants.LuaScriptTypeBuiltin},
+			},
+			wantNames: []string{"a", "b", "c"},
+			wantLen:   3,
+		},
+		{
+			name: "all entries duplicate the same name",
+			input: []InspectionLuaScript{
+				{Name: "same", ScriptCode: "code-1", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "same", ScriptCode: "code-2", ScriptType: constants.LuaScriptTypeBuiltin},
+				{Name: "same", ScriptCode: "code-3", ScriptType: constants.LuaScriptTypeBuiltin},
+			},
+			wantNames: []string{"same"},
+			wantLen:   1,
+		},
+		{
+			name:      "empty input returns empty slice",
+			input:     []InspectionLuaScript{},
+			wantNames: []string{},
+			wantLen:   0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DedupeBuiltinLuaScripts(tc.input)
+			if len(got) != tc.wantLen {
+				t.Fatalf("len(got) = %d, want %d", len(got), tc.wantLen)
+			}
+			// Ensure the input is not mutated.
+			if len(tc.input) > 0 && &tc.input[0] == &got[0] && len(tc.input) != len(got) {
+				t.Fatalf("input was mutated: input len=%d got len=%d", len(tc.input), len(got))
+			}
+			// Validate order and names.
+			for i, want := range tc.wantNames {
+				if got[i].Name != want {
+					t.Errorf("got[%d].Name = %q, want %q", i, got[i].Name, want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/plugins/modules/inspection/models/lua_scripts_builtin.go
+++ b/pkg/plugins/modules/inspection/models/lua_scripts_builtin.go
@@ -556,44 +556,6 @@ var BuiltinLuaScripts = []InspectionLuaScript{
 			print("HTTPRoute Backend Service 检查完成")
 		`,
 	}, {
-		Name:           "HTTPRoute Backend Service 存在性与端口检查",
-		Description:    "检查 HTTPRoute 所引用的后端 Service 是否存在，以及端口是否匹配 Service 的端口。",
-		Group:          "gateway.networking.k8s.io",
-		Version:        "v1",
-		Kind:           "HTTPRoute",
-		ScriptType:     constants.LuaScriptTypeBuiltin,
-		ScriptCode:     "Builtin_HTTPRoute_Backend_013",
-		TimeoutSeconds: 60, // 需要检查HTTPRoute和Service的存在性及端口匹配
-		Script: `
-			local httproutes, err = kubectl:GVK("gateway.networking.k8s.io", "v1", "HTTPRoute"):AllNamespace(""):List()
-			if err then print("获取 HTTPRoute 失败: " .. tostring(err)) return end
-			for _, route in ipairs(httproutes) do
-				if route.spec and route.spec.rules then
-					for _, rule in ipairs(route.spec.rules) do
-						if rule.backendRefs then
-							for _, backend in ipairs(rule.backendRefs) do
-								local svc, err = kubectl:GVK("", "v1", "Service"):Namespace(route.metadata.namespace):Name(backend.name):Get()
-								if err or not svc then
-									check_event("失败", "HTTPRoute 使用的 Service '" .. route.metadata.namespace .. "/" .. backend.name .. "' 不存在", {namespace=route.metadata.namespace, name=backend.name})
-								else
-									local portMatch = false
-									if svc.spec and svc.spec.ports and backend.port then
-										for _, svcPort in ipairs(svc.spec.ports) do
-											if svcPort.port == backend.port then portMatch = true end
-										end
-									end
-									if not portMatch then
-										check_event("失败", "HTTPRoute 的后端 Service '" .. backend.name .. "' 使用端口 '" .. tostring(backend.port) .. "'，但 Service 未配置该端口", {namespace=route.metadata.namespace, name=backend.name, port=backend.port})
-									end
-								end
-							end
-						end
-					end
-				end
-			end
-			print("HTTPRoute Backend Service 检查完成")
-		`,
-	}, {
 		Name:           "HTTPRoute Gateway 存在性与命名空间策略检查",
 		Description:    "检查 HTTPRoute 所引用的 Gateway 是否存在，以及 Gateway 的 AllowedRoutes 策略是否允许该 HTTPRoute。",
 		Group:          "gateway.networking.k8s.io",


### PR DESCRIPTION
修复 #469

## 问题

`pkg/plugins/modules/inspection/models/lua_scripts_builtin.go` 的 `BuiltinLuaScripts` 数组里有两条 HTTPRoute Backend Service 检查条目：

- Name 都是 "HTTPRoute Backend Service 存在性与端口检查"
- ScriptCode 分别是 `Builtin_HTTPRoute_Backend_012` / `Builtin_HTTPRoute_Backend_013`
- Lua 脚本内容（去掉空白后）逐字符相同，等于开发者复制粘贴时只改了 ScriptCode 后缀、忘了改 Name

`inspection_lua_scripts.name` 上有 UNIQUE 索引，所以插件首次安装时 `AddBuiltinLuaScripts` 调用 `CreateInBatches` 插入 39 条数据，遇到这两条 Name 重复就报 `UNIQUE constraint failed: inspection_lua_scripts.name (2067)`。

因为问题出在 source data，卸载重装并不能解决。

## 修复

1. **删掉重复条目**：保留 ScriptCode 为 `..._012` 的那条（内容与 013 完全相同）
2. **AddBuiltinLuaScripts 接入去重**：`models/db.go` 新增 `DedupeBuiltinLuaScripts` 按 Name 去重，插入前先调用作为防御
3. **admin "重新加载内置脚本" 入口同样接入去重**：`controller/scripts.go` 的 `LuaScriptLoad`，避免该路径触发同样的 bug
4. **回归测试**：新增 `models/db_test.go`
   - 表驱动测试 `TestDedupeBuiltinLuaScripts` 覆盖 dedupe 逻辑（无重复/单重/多重/全重/空输入）
   - 锁定内置脚本源数据 Name/ScriptCode 唯一性的 `TestBuiltinLuaScriptsHaveUniqueNames` / `TestBuiltinLuaScriptsHaveUniqueScriptCodes`，防止以后再因复制粘贴引入同类问题

## 改动文件

- `pkg/plugins/modules/inspection/models/lua_scripts_builtin.go` （-38 行）
- `pkg/plugins/modules/inspection/models/db.go` （+20 行）
- `pkg/plugins/modules/inspection/controller/scripts.go` （+3 行）
- `pkg/plugins/modules/inspection/models/db_test.go` （新文件，+118 行）

合计 4 files changed, 142 insertions(+), 41 deletions(-)

## 验证

本机无 Go 工具链，`docker pull golang:1.24-alpine` 在当前网络下卡住，未本地跑 `go build` / `go test`。CI 上 Go 1.24 + 仓库既有 `make test` 会执行 `go test -v ./...`，会自然覆盖新加的测试。