### PR TITLE
ci(workflows): bump Node.js from 18 to 22 in pnpm-based jobs

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 使用 Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 22
           cache: "pnpm"
           cache-dependency-path: "ui/pnpm-lock.yaml"
       - name: 编译前端

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 使用 Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 22
           cache: "pnpm"
           cache-dependency-path: "ui/pnpm-lock.yaml"
 


### PR DESCRIPTION
ci(workflows): bump Node.js from 18 to 22 in pnpm-based jobs

Both `build-docker-image.yml` and `build-release.yml` use
`pnpm/action-setup@v4` with `version: latest`, but `setup-node` is
configured with `node-version: 18`. The current `pnpm` latest requires
Node 22.13+, so every push to main and every release event has been
failing at the Node.js step with:

> ERROR: This version of pnpm requires at least Node.js v22.13
> The current version of Node.js is v18.20.8

## What's broken

- `build docker image` workflow: failing on every push to main since
  between 2026-04-10 (last success: Update README.md) and 2026-08-13
  (PR #470 was the first failed push I observed).
- `build and push binary to release` workflow: last failed on
  v0.26.17 (2026-03-05).

## Why bump Node to 22 (not pin pnpm)

- Node.js 18 reached EOL in April 2025; staying on 18 is the wrong
  long-term direction.
- The workflows use Node only to run pnpm for the frontend build, no
  Node 18-specific features are relied on.
- Pinning pnpm to an old version (e.g. `9.x`) would also work and is a
  reasonable alternative if 22 is not desired.

## Files changed

- `.github/workflows/build-docker-image.yml`: `node-version: 18` → `22`
- `.github/workflows/build-release.yml`: `node-version: 18` → `22`

Total diff: 2 files, 2 insertions, 2 deletions.

## Verification

This PR itself is the first push to main after the fix, so the next
`build docker image` run will validate end-to-end. If that run is
green, the fix is confirmed.