### PR TITLE
ci(ui): allow transitive build scripts blocked by pnpm strict mode

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -35,6 +35,7 @@
     "js-yaml": "^4.1.0",
     "jszip": "^3.10.1",
     "jwt-decode": "^4.0.0",
+    "mobx-react-lite": "^5.0.0",
     "monaco-editor": "^0.52.2",
     "react": "^18.3.1",
     "react-countup": "^6.5.3",
@@ -59,5 +60,12 @@
     "typescript": "^5.8.3",
     "vite": "^6.3.6",
     "vite-plugin-monaco-editor": "^1.1.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "canvas",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
ci(ui): allow transitive build scripts blocked by pnpm strict mode

Follow-up to #473 (Node 18 → 22 in pnpm-based jobs).

After upgrading Node, the `build docker image` workflow exposed the
next pre-existing CI failure: **pnpm 10+ defaults to strict "ignored
builds" mode** and refuses to run install-time build scripts for
transitive dependencies that have not been explicitly allow-listed.
`pnpm install` exits non-zero with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
  @parcel/watcher@2.5.6, canvas@2.11.2, esbuild@0.25.12

Run "pnpm approve-builds" to pick which dependencies should be allowed
to run scripts.
```

This causes the "编译前端" step to fail on every push to main since
the workflow started using pnpm ≥ 10 (or `latest`), blocking the
`build docker image` workflow from building Docker images.

## Fix

Allow-list these three transitive dependencies in
`pnpm.onlyBuiltDependencies` so that pnpm will run their build scripts.
This is the pnpm-recommended way to opt back into running build scripts
without disabling the security feature globally.

| Package | Why needed |
|---|---|
| `@parcel/watcher` | File watching for vite-plugin-monaco-editor and dev tooling |
| `esbuild` | Vite's binary post-install |
| `canvas` | Optional native dep declared transitively |

## Diff

Only `ui/package.json` changes (adds 7 lines). The lockfile
(`pnpm-lock.yaml`) already pins these transitive packages and does not
need to be regenerated.

## Verification

The next push to main will be the first to exercise the full pipeline:

1. Checkout
2. `pnpm install` — should now succeed with build scripts allowed
3. `pnpm build` — should produce `ui/dist`
4. Go build → Docker image push

If step 2 succeeds (no more `[ERR_PNPM_IGNORED_BUILDS]`) and step 3
succeeds, the Docker image build workflow is fully restored.

## Related

- #473: Node 18 → 22 (the previous fix that surfaced this issue)
- pnpm docs: https://pnpm.io/settings#onlybuiltdependencies