### PR TITLE
ci(workflows): use --ignore-scripts for pnpm install

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -47,9 +47,7 @@ jobs:
       - name: 编译前端
         run: |
           cd ui
-          pnpm install --no-frozen-lockfile
-          pnpm approve-builds --all || true
-          pnpm install --frozen-lockfile
+          pnpm install --ignore-scripts
           pnpm build
 
       - name: 设置go环境

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,9 +24,7 @@ jobs:
       - name: 编译前端
         run: |
           cd ui
-          pnpm install --no-frozen-lockfile
-          pnpm approve-builds --all || true
-          pnpm install --frozen-lockfile
+          pnpm install --ignore-scripts
           pnpm build
 
       - name: 上传到共享


### PR DESCRIPTION
ci(workflows): use --ignore-scripts for pnpm install

PR #475 was merged but the build docker image workflow is still
failing on the "编译前端" step with [ERR_PNPM_IGNORED_BUILDS].

## Why #475's approach didn't fully work

#475 used `pnpm install --no-frozen-lockfile && pnpm approve-builds
--all && pnpm install --frozen-lockfile`. The intent was that the
first install would let pnpm refresh the lockfile, the approve step
would populate node_modules/.modules.yaml, and the second install
would pass cleanly. In practice:

1. The first `pnpm install --no-frozen-lockfile` exits non-zero with
   `[ERR_PNPM_IGNORED_BUILDS]` because pnpm 11 sees three transitive
   build scripts (@parcel/watcher, canvas, esbuild) it does not yet
   know about.
2. The GitHub Actions runner uses `bash -e` (default for `run:`
   blocks), so the non-zero exit aborts the step before
   `pnpm approve-builds` runs.
3. Even after approval, the canvas node-gyp compile would fail on
   the ubuntu-latest runner because cairo/pango are not installed.

## Fix

Replace the four-line install + approve dance with a single
`pnpm install --ignore-scripts`. This tells pnpm to skip ALL
install-time build scripts, which:

1. Eliminates the `[ERR_PNPM_IGNORED_BUILDS]` error: pnpm 11 only
   complains about scripts it tried to run and was blocked from
   running; with `--ignore-scripts` nothing is blocked.
2. Avoids the canvas node-gyp compile failure on the CI runner
   (canvas is an optional native dep; amis falls back gracefully
   when its native binary is missing).
3. Does NOT break the downstream `pnpm build` step: vite uses its
   bundled esbuild (pnpm 11 ships esbuild with prebuilt binaries
   for all common platforms).

## Verification

Tested locally with pnpm 11.21 + CI=true:

    $ CI=true pnpm install --ignore-scripts
    ... Done in 4.1s using pnpm v11.21.0 (exit 0)

    $ pnpm build
    ... ✓ built in 2m 33s (exit 0)
    $ ls dist/index.html dist/assets/  # 345 asset files

## Files changed

- `.github/workflows/build-docker-image.yml`: replace 3 install
  lines with 1 install line
- `.github/workflows/build-release.yml`: same

Net: -4 lines, no other changes. The `pnpm build` step is
unchanged. The lockfile from #475 is preserved.

## Notes

- The nested `pnpm.onlyBuiltDependencies` from #474 is harmless
  under pnpm 11 (warning emitted, field ignored) and kept for
  pnpm 10 backward compatibility.
- This PR supersedes the strategy proposed in #475's body text
  (the `--no-frozen-lockfile` / approve-builds / `--frozen-lockfile`
  approach). The fix shipped in #475 (lockfile refresh, mobx-react-lite
  importer entry) is preserved.