### PR TITLE
ci(workflows): disable SLSA provenance to fix Aliyun registry push

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -116,6 +116,14 @@ jobs:
           cache-from: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache
           cache-to: type=registry,ref=${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:buildcache,mode=max
           platforms: linux/amd64,linux/arm64
+          # Disable SLSA provenance attestation: the OCI 1.1 empty
+          # descriptor it emits is rejected by registry.cn-hangzhou
+          # (Aliyun personal registry). DockerHub and ghcr.io accept
+          # it, but a single registry failure aborts the whole
+          # multi-destination push. Setting `provenance: false` keeps
+          # all three registries in sync at the cost of supply-chain
+          # attestation.
+          provenance: false
           # 给清单打上多个标签
           tags: |
             ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_REPONAME }}:latest


### PR DESCRIPTION
ci(workflows): disable SLSA provenance to fix Aliyun registry push

The `build docker image` workflow was failing on `Build and push`
with:

    ERROR: failed to push registry.cn-hangzhou.aliyuncs.com/minik8m/k8m:main:
    denied: unknown manifest class for application/vnd.oci.empty.v1+json

Root cause:

`docker/build-push-action@v6` defaults to
`--attest type=provenance,mode=max`, which generates a SLSA
provenance attestation containing OCI 1.1 empty descriptors
(mediaType `application/vnd.oci.empty.v1+json`).

- DockerHub (`docker.io/weibh/k8m`) accepts the empty descriptor:
  push succeeds.
- ghcr.io (`ghcr.io/weibaohui/k8m`) accepts the empty descriptor:
  push succeeds.
- registry.cn-hangzhou.aliyuncs.com (Aliyun personal registry)
  rejects the empty descriptor: push denied.

Because the workflow uses `--tag` for three registries in a single
multi-destination push, ANY failure aborts the whole batch. So the
Aliyun denial blocked the ghcr.io tags from being pushed too.

## Fix

Add `provenance: false` to the `docker/build-push-action@v6` step.
This drops the SLSA provenance attestation (and the empty
descriptor that comes with it), making the manifest compatible with
the OCI 1.0 subset that Aliyun's registry accepts. All three
registries will then receive the same tags.

## Trade-off

We lose the SLSA provenance attestation for k8m images. This is a
supply-chain hardening feature that lets consumers verify the image
came from this GitHub Actions run. Disabling it means image
provenance is unverifiable via buildx attestations.

For the k8m project this trade-off is acceptable because:
1. Aliyun is the primary Chinese distribution channel and pushing
   there is required.
2. ghcr.io and DockerHub users can still rely on git-source
   provenance (the repo's signed git history) for verification.
3. The k8m release workflow tags images with a date+ref tag, which
   ties them to a specific commit hash verifiable via git.

## Files changed

- `.github/workflows/build-docker-image.yml`: add `provenance: false`

No other workflows need this — `build-release.yml` uses the standard
`go build` flow without docker/build-push-action.